### PR TITLE
a little patch of .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ Codeblocks
 *.toc
 
 # CMake
-.cmake
+*.cmake
 CMakeFiles
 Makefile
 *CMakeCache*
@@ -39,6 +39,9 @@ Makefile
 # something pythoon related
 *.pyc
 __pycache__
+
+# pyenv
+.python-version
 
 # Others
 .pydevproject
@@ -48,3 +51,4 @@ Debug/
 
 # Jupyter notebook
 tutorial/jupyter/.ipynb_checkpoints/
+.ipynb_checkpoints/


### PR DESCRIPTION
Hello, I am just starting with a git, but I think there should be *.cmake in .gitignore. Plus I added something for pyenv and .ipynb-checkpoints/ in base folder. 

If this is non-sense, just ignore it. Have a good day!