### PR TITLE
WIP: Modify build system to allow generation of wheels and Debian packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ tutorial/jupyter/.ipynb_checkpoints/
 
 # images
 *.png
+
+# Python packaging/setup.py directories
+dist/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,3 +21,13 @@ add_subdirectory(src)
 
 # build tutorial (TODO)
 # INCLUDE(UseLATEX.cmake)
+
+execute_process(
+	COMMAND
+		${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/src/external/sundials ${CMAKE_CURRENT_BINARY_DIR}/src/external/sundials
+)
+
+execute_process(
+	COMMAND
+		${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/src/external/suitsparse ${CMAKE_CURRENT_BINARY_DIR}/src/external/suitsparse
+)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include README.md LICENSE src/external/pybind11/LICENSE
+graft src
+global-include CMakeLists.txt *.cmake
+
+# excludes
+exclude CMakeCache.txt
+recursive-exclude build/
+recursive-exclude dist/
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,175 @@
+"""
+setup.py that calls cmake to compile a C/C++-based module
+
+Modified from: https://github.com/pybind/cmake_example/tree/master
+
+commit:
+
+https://github.com/pybind/cmake_example/commit/e29e2cb9d59484b83e50febeeda3898950fbde9f
+
+"""
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
+from setuptools import find_packages
+
+
+# Convert distutils Windows platform specifiers to CMake -A arguments
+PLAT_TO_CMAKE = {
+    "win32": "Win32",
+    "win-amd64": "x64",
+    "win-arm32": "ARM",
+    "win-arm64": "ARM64",
+}
+
+
+# A CMakeExtension needs a sourcedir instead of a file list.  The name must be
+# the _single_ output extension from the CMake build.  If you need multiple
+# extensions, see scikit-build.
+class CMakeExtension(Extension):
+    def __init__(self, name: str, sourcedir: str = "") -> None:
+        super().__init__(name, sources=[])
+        self.sourcedir = os.fspath(Path(sourcedir).resolve())
+
+
+class CMakeBuild(build_ext):
+    def build_extension(self, ext: CMakeExtension) -> None:
+        # Must be in this form due to bug in .resolve() only fixed in Python
+        # 3.10+
+        ext_fullpath = Path.cwd() / self.get_ext_fullpath(ext.name)
+        extdir = ext_fullpath.parent.resolve()
+
+        # Using this requires trailing slash for auto-detection & inclusion of
+        # auxiliary "native" libs
+
+        debug = int(
+            os.environ.get("DEBUG", 0)
+        ) if self.debug is None else self.debug
+        cfg = "Debug" if debug else "Release"
+
+        # CMake lets you override the generator - we need to check this.
+        # Can be set with Conda-Build, for example.
+        cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
+
+        # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
+        # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code
+        # from Python.
+        cmake_args = [
+            f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
+            f"-DPYTHON_EXECUTABLE={sys.executable}",
+            f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
+        ]
+        build_args = []
+        # Adding CMake arguments set as environment variable
+        # (needed e.g. to build for ARM OSx on conda-forge)
+        if "CMAKE_ARGS" in os.environ:
+            cmake_args += [
+                item for item in os.environ["CMAKE_ARGS"].split(" ") if item
+            ]
+
+        # In this example, we pass in the version to C++. You might not need
+        # to.
+        # cmake_args += [
+        #     f"-DEXAMPLE_VERSION_INFO={self.distribution.get_version()}"
+        # ]
+
+        if self.compiler.compiler_type != "msvc":
+            # Using Ninja-build since it a) is available as a wheel and b)
+            # multithreads automatically. MSVC would require all variables be
+            # exported for Ninja to pick it up, which is a little tricky to do.
+            # Users can override the generator with CMAKE_GENERATOR in CMake
+            # 3.15+.
+            if not cmake_generator or cmake_generator == "Ninja":
+                try:
+                    import ninja
+
+                    ninja_executable_path = Path(ninja.BIN_DIR) / "ninja"
+                    cmake_args += [
+                        "-GNinja",
+                        "-DCMAKE_MAKE_PROGRAM:FILEPATH=" +
+                        f"{ninja_executable_path}",
+                    ]
+                except ImportError:
+                    pass
+
+        else:
+            # Single config generators are handled "normally"
+            single_config = any(
+                x in cmake_generator for x in {"NMake", "Ninja"}
+            )
+
+            # CMake allows an arch-in-generator style for backward
+            # compatibility
+            contains_arch = any(x in cmake_generator for x in {"ARM", "Win64"})
+
+            # Specify the arch if using MSVC generator, but only if it doesn't
+            # contain a backward-compatibility arch spec already in the
+            # generator name.
+            if not single_config and not contains_arch:
+                cmake_args += ["-A", PLAT_TO_CMAKE[self.plat_name]]
+
+            # Multi-config generators have a different way to specify configs
+            if not single_config:
+                cmake_args += [
+                    f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{cfg.upper()}={extdir}"
+                ]
+                build_args += ["--config", cfg]
+
+        if sys.platform.startswith("darwin"):
+            # Cross-compile support for macOS - respect ARCHFLAGS if set
+            archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
+            if archs:
+                cmake_args += [
+                    "-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))
+                ]
+
+        # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
+        # across all generators.
+        if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
+            # self.parallel is a Python 3 only way to set parallel jobs by hand
+            # using -j in the build_ext call, not supported by pip or
+            # PyPA-build.
+            if hasattr(self, "parallel") and self.parallel:
+                # CMake 3.12+ only.
+                build_args += [f"-j{self.parallel}"]
+
+        build_temp = Path(self.build_temp) / ext.name
+        if not build_temp.exists():
+            build_temp.mkdir(parents=True)
+
+        subprocess.run(
+            ["cmake", ext.sourcedir, *cmake_args], cwd=build_temp, check=True
+        )
+        subprocess.run(
+            ["cmake", "--build", ".", *build_args], cwd=build_temp, check=True
+        )
+
+
+# The information here can also be placed in setup.cfg - better separation of
+# logic and declaration, and simpler if you include description/version in a
+# file.
+setup(
+    name="CPlantBox",
+    version="2.0+git",
+    author="?",
+    author_email="?",
+    description="CPlantBox",
+    long_description="",
+    ext_modules=[CMakeExtension("plantbox")],
+    cmdclass={"build_ext": CMakeBuild},
+    zip_safe=False,
+    # extras_require={"test": ["pytest>=6.0"]},
+    python_requires=">=3.7",
+    packages=find_packages("src"),
+    package_dir={'': 'src'},
+    install_requires=[
+        'numpy',
+        'scipy',
+        'vtk',
+    ],
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,7 +124,7 @@ target_link_libraries(CPlantBox
 						libklu
 						)
 
-set_target_properties(CPlantBox PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/)
+	# set_target_properties(CPlantBox PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/)
 target_include_directories(
                         CPlantBox
                         PUBLIC
@@ -141,13 +141,13 @@ find_package( PythonInterp 3.7 REQUIRED )
 find_package( PythonLibs 3.7 REQUIRED )
 add_subdirectory(external/pybind11)
 
-pybind11_add_module(plantbox SHARED 
-			PyPlantBox.cpp   								
+pybind11_add_module(plantbox MODULE
+			PyPlantBox.cpp
 			)
 target_link_libraries(plantbox PUBLIC 
 			CPlantBox)
-			
-set_target_properties(plantbox PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/)
+
+# set_target_properties(plantbox PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/)
 
 
 


### PR DESCRIPTION
Hi,

or internal use we wanted to distribute CPlantBox either via Python wheels or using Debian packages, and I could not find any information on that in the code.  Therefore, I thought our changes might be interesting to other users of CPlantBox. However,  feel free to close the PR or suggest relevant changes in case you want to keep (some) of these changes.

In order to generate the packages, some changes to the build system were required - I'm not completely sure if these changes have any unintended side effects for other general use cases of CPlantBox (i.e., I had to revert the target location of the .so files back to their default).

Anyway, the current state allows the generation of wheels and Debian packages, as tested on a Debian bookworm and an old Debian 10.13 (Buster) installation. Please also note that wheels could directly be uploaded to pypi.org, enabling to install CPlantBox easily via an `pip install cplantbox` for supported architectures/interpreters.

## Build instructions

Starting in a clean virtualenv:

`pip install build wheel ninja`

I had some problems with the pybind11 version, but 2.4 and 2.11.1 finally worked:
```
cd src/external/
rm -rf pybind11
# for older systems (i.e. Debian 10.13)
git clone --depth 1 -b v2.4 https://github.com/pybind/pybind11.git
# Debian Bookworm worked with:
git clone --depth 1 -b v2.11.1 https://github.com/pybind/pybind11.git
```

Wheels are then built with:

`python setup.py bdist_wheel`
or
`python -m build --wheel`


## Debian packaging

```
# on Debian ookworm
pip install stdeb
# for Debian Buster:
pip install stdeb==0.9.1
pip install setuptools==40.8.0

```

The Debian packages are then generated using:

`python3 setup.py --command-packages=stdeb.command bdist_deb`

output is located in **deb_dist/**



