### PR TITLE
Master4 trai rhizo

### DIFF
--- a/modelparameter/structural/plant/Triticum_aestivum_test_2021 (1).xml:Zone.Identifier
+++ b/modelparameter/structural/plant/Triticum_aestivum_test_2021 (1).xml:Zone.Identifier
@@ -1,0 +1,4 @@
+[ZoneTransfer]
+ZoneId=3
+ReferrerUrl=https://ibg3113.ibg.kfa-juelich.de/user/m.giraud/lab/workspaces/auto-y/tree/DumuxDune27/DUMUX/dumux-rosi/cpp/python_binding/solverbase.hh
+HostUrl=https://ibg3113.ibg.kfa-juelich.de/user/m.giraud/files/DumuxDune27/DUMUX/CPlantBox/modelparameter/structural/plant/Triticum_aestivum_test_2021.xml?_xsrf=2%7C5b23d1e2%7C8453a20aade48c7f8fe543312498ac33%7C1709791245

--- a/modelparameter/structural/plant/Triticum_aestivum_test_2021 (1).xml:Zone.Identifier
+++ b/modelparameter/structural/plant/Triticum_aestivum_test_2021 (1).xml:Zone.Identifier
@@ -1,4 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=https://ibg3113.ibg.kfa-juelich.de/user/m.giraud/lab/workspaces/auto-y/tree/DumuxDune27/DUMUX/dumux-rosi/cpp/python_binding/solverbase.hh
-HostUrl=https://ibg3113.ibg.kfa-juelich.de/user/m.giraud/files/DumuxDune27/DUMUX/CPlantBox/modelparameter/structural/plant/Triticum_aestivum_test_2021.xml?_xsrf=2%7C5b23d1e2%7C8453a20aade48c7f8fe543312498ac33%7C1709791245

--- a/modelparameter/structural/plant/Triticum_aestivum_test_2021.xml
+++ b/modelparameter/structural/plant/Triticum_aestivum_test_2021.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plant name="Triticum_aestivum_a_Bingham_2011_new" filetype="parameters">
+<organ type="seed" name="true" subType="0">
+        <parameter name="maxTi" value="5" dev="0"/>
+        <parameter name="firstTi" value="6"/>
+        <parameter name="delayTi" value="10"/>
+        <!--Maximal number of tillers [1]-->
+        <parameter name="delayB" value="3" dev="0"/>
+        <!--Time delay between the basal roots [day]-->
+        <parameter name="delayRC" value="1000"/>
+        <!--Delay between the root crowns [day]-->
+        <parameter name="delaySB" value="1000"/>
+        <!--Time delay between the shoot borne roots [day]-->
+        <parameter name="firstB" value="1"/>
+        <!--Emergence of first basal root [day]-->
+        <parameter name="firstSB" value="1000"/>
+        <!--First emergence of a shoot borne root [day]-->
+        <parameter name="maxB" value="15" dev="0"/>
+        <!--Maximal number of basal roots [1]-->
+        <parameter name="nC" value="0"/>
+        <!--Maximal number of roots per root crown [1]-->
+        <parameter name="nz" value="0"/>
+        <!--Distance between the root crowns along the shoot [cm]-->
+        <parameter name="seedPos.x" value="0"/>
+        <!--X-Coordinate of seed position [cm]-->
+        <parameter name="seedPos.y" value="0"/>
+        <!--Y-Coordinate of seed position [cm]-->
+        <parameter name="seedPos.z" value="-0.3"/>
+        <!--Z-Coordinate of seed position [cm]-->
+		<parameter name="delayDefinition" value="1"/>
+        <parameter name="simulationTime" value="240"/>
+        <!--Recommended final simulation time  [day]-->
+</organ>
+
+<organ type="root" name="taproot" subType="1">
+        <parameter name="la" value="12" dev="0"/>
+	<parameter name="ldelay" value="4" dev="0" />
+        <!--Apical zone [cm]-->
+        <parameter name="lb" value="0.8" dev="0"/>
+        <!--parameter name="ln" value="0.8" dev="0.03"/-->
+        <parameter name="ln" value="0.4" dev="0"/>
+    <!--Inter-lateral distance [cm];-->
+    <parameter name="lmax" value="60" dev="0"/>
+    <!--Inter-lateral distance [cm];-->
+        <parameter name="r" value="2.4" dev="0"/>
+     <parameter name="a" value="0.05" dev="0"/>
+    <parameter name="tropismT" value="1"/>
+    <parameter name="tropismN" value="0.5"/>
+    <parameter name="tropismS" value="0.261799"/>
+    <parameter name="dx" value="3"/>
+    <parameter name="dxMin" value="1"/>
+    <parameter name="theta" value="0.4" dev="0.0"/>
+    <parameter name="rlt" value="1000000000" dev="0"/>
+    <parameter name="gf" value="3"/>
+    <parameter name="successor" number="0" type="2" percentage="1"/>
+</organ>
+
+<organ type="root" name="lateral1" subType="2">
+    <parameter name="lb" value="1" dev="0"/>
+    <!--Basal zone [cm]-->
+    <parameter name="la" value="5" dev="0"/>
+    <!--Apical zone [cm];-->
+    <parameter name="ln" value="0.25" dev="0"/>
+    <!--parameter name="ln" value="0.15" dev="0.01"/-->
+    <!--Inter-lateral distance [cm]-->
+    <parameter name="lmax" value="10"/>
+    <!--Inter-lateral distance [cm]1.5;-->
+    <parameter name="r" value="1" dev="0"/>
+    <parameter name="a" value="0.020" dev="0"/>
+    <parameter name="tropismT" value="1"/>
+    <parameter name="tropismN" value="1"/>
+    <parameter name="tropismS" value="0.5"/>
+    <parameter name="theta" value="0.79" />
+    <parameter name="dx" value="3"/>
+    <parameter name="dxMin" value="1"/>
+	<parameter name="ldelay" value="5" dev="0" />
+    <parameter name="rlt" value="1000000000" dev="0"/>
+    <parameter name="gf" value="3"/>
+    <parameter name="successor" number="0" type="3" percentage="1"/>
+</organ>
+
+<organ type="root" name="lateral2" subType="3">
+    <parameter name="lmax" value="4" dev="0"/>
+    <parameter name="lb" value="1" dev="0"/>
+    <parameter name="la" value="3" dev="0"/>
+    <parameter name="r" value="0.6" dev="0"/>
+    <parameter name="a" value="0.02" dev="0"/>
+    <parameter name="tropismT" value="1"/>
+    <parameter name="tropismN" value="1"/>
+    <parameter name="tropismS" value="0.40000000000000002"/>
+    <parameter name="dx" value="3"/>
+    <parameter name="dxMin" value="1"/>
+    <parameter name="theta" value="0.95993099999999998" dev="0"/>
+    <parameter name="rlt" value="1000000000" dev="0"/>
+    <parameter name="gf" value="3"/>
+</organ>
+
+<organ type="stem" name="mainstem" subType="1">
+    <!--Basal zone [cm]-->
+    <parameter name="lb" value="1" dev="0"/>
+    <!--Basal zone [cm]-->
+    <parameter name="la" value="0" dev="0"/>
+    <!--Apical zone [cm];-->
+    <parameter name="ln" value="8.75" dev="0" functiontype="0"/>
+    <!--Inter-lateral distance [cm];-->
+    <parameter name="lmax" value="35" dev="0"/>
+    <parameter name="r" value="1" dev="0" />
+    <!--delayNG = 33.4 - lb/r;-->
+	<!--parameter name="delayNG" value="29.4" dev="6.3" /-->
+	<parameter name="ldelay" value="10" dev="0" />
+	<parameter name="nodalGrowth" value="0" />
+	<parameter name="delayNGStart" value="4"  />
+	<parameter name="delayNGEnd" value="24"  />
+    <parameter name="a" value="0.15" dev="0" />
+    <!--parameter name="a_x_eq" value="0.3068" /!-->
+    <parameter name="tropismT" value="1"/>
+    <parameter name="tropismN" value="1"/>
+    <parameter name="tropismS" value="0.01"/>
+    <parameter name="dx" value="1"/>
+    <!--parameter name="dxMin" value="2"/-->
+    <parameter name="dxMin" value="0.1"/>
+    <parameter name="theta" value="0.1" dev="0"/>
+    <!--parameter name="BetaDev" value="1" dev="0"/-->
+    <!--parameter name="RotBeta" value="1" dev="0"/-->
+    <parameter name="rlt" value="1000000000" dev="0"/>
+    <parameter name="gf" value="3"/>
+    <parameter name="successor" number="0" subType="1" organType ="4" percentage="1"/>
+</organ>
+
+
+<organ type="leaf" name="lateral1" subType="1">
+    <parameter name="lb" value="8" dev="0"/>
+    <!--Basal zone [cm]-->
+    <parameter name="la" value="35" dev="0"/>
+    <!--Apical zone [cm];-->
+    <parameter name="ln" value="0" dev="0" functiontype="3"/>
+    <!--Inter-lateral distance [cm];-->
+    <parameter name="lmax" value="43" dev="0"/>
+    <parameter name="r" value="4" dev="0"/>
+    <parameter name="a" value="0.03" dev="0"/>
+    <parameter name="Width_petiole" value="0.35" />
+    <parameter name="Width_blade" value="0.9" />
+    <parameter name="shapeType" value="1" />
+    <parameter name="tropismT" value="1"/>
+    <parameter name="tropismN" value="18"/>
+    <parameter name="tropismS" value="0.02"/>
+    <parameter name="dx" value="2"/>
+    <parameter name="dxMin" value="1"/>
+    <parameter name="theta" value="0.2" dev="0"/>
+    <parameter name="rlt" value="1000000000" dev="0"/>
+    <parameter name="gf" value="3"/>
+	<parameter name="areaMax" value="35"/>
+	<parameter name="isPseudostem" value="1"/>
+    <parameter name="geometryN" value="100"/>
+    <parameter name="parametrisationType" value="1"/>
+	<parameter name="leafGeometry" phi="-3, -2.1, 0., 2.45, 3.5" x="1., 1., 1., 1., 1."/>
+</organ>
+
+
+</plant>

--- a/src/PyPlantBox.cpp
+++ b/src/PyPlantBox.cpp
@@ -689,7 +689,7 @@ PYBIND11_MODULE(plantbox, m) {
       .def_readwrite("f_sbp", &LeafRandomParameter::f_sbp)
       .def_readwrite("tropismAge", &LeafRandomParameter::tropismAge)
       .def_readwrite("tropismAges", &LeafRandomParameter::tropismAges)
-    ;
+       .def_readwrite("Width_blade", &LeafRandomParameter::Width_blade)  ;
     py::class_<LeafSpecificParameter, OrganSpecificParameter, std::shared_ptr<LeafSpecificParameter>>(m, "LeafSpecificParameter")
             .def(py::init<>())
             .def(py::init<int , double, double, const std::vector<double>&, double, double, double, double, double, bool, double, double>())
@@ -862,7 +862,7 @@ PYBIND11_MODULE(plantbox, m) {
         .def("setSoilGrid", (void (MappedSegments::*)(const std::function<int(double,double,double)>&)) &MappedSegments::setSoilGrid)
         .def("setSoilGrid", (void (MappedSegments::*)(const std::function<int(double,double,double)>&, Vector3d, Vector3d, Vector3d, bool)) &MappedSegments::setSoilGrid,
         		py::arg("s"), py::arg("min"), py::arg("max"), py::arg("res"), py::arg("cut") = true)
-        .def("setRectangularGrid", &MappedSegments::setRectangularGrid, py::arg("min"), py::arg("max"), py::arg("res"), py::arg("cut") = true)
+        .def("setRectangularGrid", &MappedSegments::setRectangularGrid, py::arg("min"), py::arg("max"), py::arg("res"), py::arg("cut") = true, py::arg("noChanges") = false)
         .def("mapSegments",  &MappedSegments::mapSegments)
         .def("cutSegments", &MappedSegments::cutSegments)
         .def_readwrite("soil_index", &MappedSegments::soil_index)
@@ -924,6 +924,8 @@ PYBIND11_MODULE(plantbox, m) {
 			.def("getSegmentIds",&MappedPlant::getSegmentIds)
 			.def_readwrite("leafBladeSurface",  &MappedPlant::leafBladeSurface)
 			.def_readwrite("bladeLength",  &MappedPlant::bladeLength)
+			.def_readwrite("exchangeZoneCoefs", &MappedPlant::exchangeZoneCoefs)
+			.def_readwrite("distanceTip", &MappedPlant::distanceTip)
 			.def("getNodeIds",&MappedPlant::getNodeIds);
 
 	/**
@@ -941,15 +943,18 @@ PYBIND11_MODULE(plantbox, m) {
     py::class_<XylemFlux, std::shared_ptr<XylemFlux>>(m, "XylemFlux")
             .def(py::init<std::shared_ptr<CPlantBox::MappedSegments>>())
             .def(py::init<std::shared_ptr<CPlantBox::MappedPlant>>())
-            .def("setKr",py::overload_cast<std::vector<double>, std::vector<double>> (&XylemFlux::setKr), py::arg("values"), py::arg("age") = std::vector<double>(0))
-            .def("setKx",py::overload_cast<std::vector<double>, std::vector<double>> (&XylemFlux::setKx), py::arg("values"), py::arg("age") = std::vector<double>(0))
-            .def("setKrTables",py::overload_cast<std::vector<std::vector<double>>, std::vector<std::vector<double>>> (&XylemFlux::setKrTables))
-            .def("setKxTables",py::overload_cast<std::vector<std::vector<double>>, std::vector<std::vector<double>>> (&XylemFlux::setKxTables))
-            .def("setKr",py::overload_cast<std::vector<std::vector<double>>,std::vector<std::vector<double>>, double> (&XylemFlux::setKr), py::arg("values"), py::arg("age") = std::vector<std::vector<double>>(0),
-                                                                        py::arg("kr_length_") = -1.0)
-            .def("setKx",py::overload_cast<std::vector<std::vector<double>>,std::vector<std::vector<double>>> (&XylemFlux::setKx), py::arg("values"), py::arg("age") = std::vector<std::vector<double>>(0))
-            .def("setKrTables",py::overload_cast<std::vector<std::vector<std::vector<double>>>, std::vector<std::vector<std::vector<double>>>> (&XylemFlux::setKrTables))
-            .def("setKxTables",py::overload_cast<std::vector<std::vector<std::vector<double>>>, std::vector<std::vector<std::vector<double>>>> (&XylemFlux::setKxTables))
+            .def("setKr",py::overload_cast<std::vector<double>, std::vector<double>, bool> (&XylemFlux::setKr), 
+					py::arg("values"), py::arg("age") = std::vector<double>(0), py::arg("verbose")=false)
+            .def("setKx",py::overload_cast<std::vector<double>, std::vector<double>, bool> (&XylemFlux::setKx), py::arg("values"), py::arg("age") = std::vector<double>(0), py::arg("verbose")=false)
+            .def("setKrTables",py::overload_cast<std::vector<std::vector<double>>, std::vector<std::vector<double>>, bool, bool> (&XylemFlux::setKrTables), py::arg("values"), 
+						py::arg("age"), py::arg("verbose")=false, py::arg("ageBased")=true)
+            .def("setKxTables",py::overload_cast<std::vector<std::vector<double>>, std::vector<std::vector<double>>, bool> (&XylemFlux::setKxTables), py::arg("values"), py::arg("age"), py::arg("verbose")=false)
+            .def("setKr",py::overload_cast<std::vector<std::vector<double>>,std::vector<std::vector<double>>, double, bool> (&XylemFlux::setKr), py::arg("values"), py::arg("age") = std::vector<std::vector<double>>(0),
+                                                                        py::arg("kr_length_") = -1.0, py::arg("verbose")=false)
+            .def("setKx",py::overload_cast<std::vector<std::vector<double>>,std::vector<std::vector<double>>, bool> (&XylemFlux::setKx), py::arg("values"), py::arg("age") = std::vector<std::vector<double>>(0), py::arg("verbose")=false)
+            .def("setKrTables",py::overload_cast<std::vector<std::vector< std::vector<double> >>, std::vector<std::vector<std::vector<double>>>, bool, bool> (&XylemFlux::setKrTables), 
+					py::arg("values"), py::arg("age"), py::arg("verbose")=false, py::arg("ageBased")=true)
+            .def("setKxTables",py::overload_cast< std::vector<std::vector<std::vector<double>>>, std::vector<std::vector<std::vector<double>>>, bool> (&XylemFlux::setKxTables), py::arg("values"), py::arg("age"), py::arg("verbose")=false)
             .def("setKrValues", &XylemFlux::setKrValues)
             .def("setKxValues", &XylemFlux::setKxValues)
             .def("getEffKr", &XylemFlux::getEffKr)
@@ -963,7 +968,7 @@ PYBIND11_MODULE(plantbox, m) {
                     py::arg("cells") = false, py::arg("soil_k") = std::vector<double>())
             .def("sumSegFluxes",&XylemFlux::sumSegFluxes)
             .def("splitSoilFluxes",&XylemFlux::splitSoilFluxes, py::arg("soilFluxes"), py::arg("type") = 0)
-            .def_readonly("kr_f_cpp", &XylemFlux::kr_f)
+            .def("kr_f_cpp", &XylemFlux::kr_f_wrapped, py::arg("seg_ind"), py::arg("age"), py::arg("st"), py::arg("ot"))
             .def_readonly("kx_f_cpp", &XylemFlux::kx_f)
             .def_readwrite("aI", &XylemFlux::aI)
             .def_readwrite("aJ", &XylemFlux::aJ)
@@ -1005,6 +1010,7 @@ PYBIND11_MODULE(plantbox, m) {
             .def_readwrite("Vj", &Photosynthesis::Vj)
             .def_readwrite("fw", &Photosynthesis::fw)
             .def_readwrite("fwr", &Photosynthesis::fwr)
+            .def_readwrite("fw_cutoff", &Photosynthesis::fw_cutoff)
             .def_readwrite("sh", &Photosynthesis::sh)
             .def_readwrite("p_lcrit", &Photosynthesis::p_lcrit)
             .def_readwrite("ci", &Photosynthesis::ci)
@@ -1039,9 +1045,6 @@ PYBIND11_MODULE(plantbox, m) {
             .def_readwrite("g_canopy", &Photosynthesis::g_canopy)
             .def_readwrite("g_air", &Photosynthesis::g_air)
             .def_readwrite("theta", &Photosynthesis::theta)
-            .def_readwrite("gamma0", &Photosynthesis::gamma0)
-            .def_readwrite("gamma1", &Photosynthesis::gamma1)
-            .def_readwrite("gamma2", &Photosynthesis::gamma2)
             .def_readwrite("alpha", &Photosynthesis::alpha)
             .def_readwrite("a1", &Photosynthesis::a1)
             .def_readwrite("a2_stomata", &Photosynthesis::a2_stomata)
@@ -1056,7 +1059,10 @@ PYBIND11_MODULE(plantbox, m) {
             .def_readwrite("outputFlux", &Photosynthesis::outputFlux)
             .def_readwrite("outputFlux_old", &Photosynthesis::outputFlux_old)
             .def_readwrite("doLog", &Photosynthesis::doLog)
-            .def_readwrite("R_ph", &Photosynthesis::R_ph);
+            .def_readwrite("R_ph", &Photosynthesis::R_ph)
+            .def_readonly("rho_h2o", &Photosynthesis::rho_h2o)
+            .def_readonly("R_ph", &Photosynthesis::R_ph)
+            .def_readonly("Mh2o", &Photosynthesis::Mh2o);
 
     py::enum_<Photosynthesis::PhotoTypes>(m, "PhotoTypes")
             .value("C3", Photosynthesis::PhotoTypes::C3)
@@ -1070,7 +1076,7 @@ PYBIND11_MODULE(plantbox, m) {
             .def(py::init<std::shared_ptr<CPlantBox::MappedPlant>, double, double>(),  py::arg("plant_"),
 			py::arg("psiXylInit"),  py::arg("ciInit") )
             .def("waterLimitedGrowth",&PhloemFlux::waterLimitedGrowth)
-            .def("setKr_st",&PhloemFlux::setKr_st, py::arg("values"), py::arg("kr_length_") = -1.0)
+            .def("setKr_st",&PhloemFlux::setKr_st, py::arg("values"), py::arg("kr_length_") = -1.0, py::arg("verbose") = false)
 
             .def("setKx_st",&PhloemFlux::setKx_st)
             .def("setRmax_st",&PhloemFlux::setRmax_st)
@@ -1106,8 +1112,9 @@ PYBIND11_MODULE(plantbox, m) {
             .def_readwrite("Fl",&PhloemFlux::Flv)
             //.def_readwrite("KMgr",&PhloemFlux::KMgr)
             .def_readwrite("KMfu",&PhloemFlux::KMfu)
-            //.def_readwrite("k_meso",&PhloemFlux::k_meso)
-            .def_readwrite("Csoil",&PhloemFlux::Csoil)
+            .def_readwrite("CsoilDefault",&PhloemFlux::CsoilDefault)
+            .def_readwrite("Csoil_seg",&PhloemFlux::Csoil_seg)
+            .def_readwrite("Csoil_node",&PhloemFlux::Csoil_node)
             .def_readwrite("deltaSucOrgNode",&PhloemFlux::deltaSucOrgNode_)
             .def_readwrite("usePsiXyl",&PhloemFlux::usePsiXyl)
             .def_readwrite("expression",&PhloemFlux::expression)
@@ -1139,7 +1146,20 @@ PYBIND11_MODULE(plantbox, m) {
 			.def_readwrite("GrowthZone",&PhloemFlux::GrowthZone)
 			.def_readwrite("GrowthZoneLat",&PhloemFlux::GrowthZoneLat)
 			.def_readwrite("psi_osmo_proto",&PhloemFlux::psi_osmo_proto)
-			.def_readwrite("psi_p_symplasm",&PhloemFlux::psi_p_symplasm);
+			.def_readwrite("psi_p_symplasm",&PhloemFlux::psi_p_symplasm)
+            
+            .def_readwrite("C_targ",&PhloemFlux::C_targ)
+            .def_readwrite("C_targMesophyll",&PhloemFlux::C_targMesophyll)
+            .def_readwrite("Vmax_S_ST",&PhloemFlux::Vmax_S_ST)
+            .def_readwrite("kM_S_ST",&PhloemFlux::kM_S_ST)
+            .def_readwrite("kHyd_S_ST",&PhloemFlux::kHyd_S_ST)
+            .def_readwrite("k_mucil",&PhloemFlux::k_mucil)
+            .def_readwrite("k_S_ST",&PhloemFlux::k_S_ST)
+            .def_readwrite("Vmax_S_Mesophyll",&PhloemFlux::Vmax_S_Mesophyll)
+            .def_readwrite("kM_S_Mesophyll",&PhloemFlux::kM_S_Mesophyll)
+            .def_readwrite("kHyd_S_Mesophyll",&PhloemFlux::kHyd_S_Mesophyll)
+            .def_readwrite("k_S_Mesophyll",&PhloemFlux::k_S_Mesophyll)
+            .def_readwrite("k_mucil_",&PhloemFlux::k_mucil_);
 
     py::class_<PlantVisualiser, std::shared_ptr<PlantVisualiser>>(m, "PlantVisualiser")
         .def(py::init<>())

--- a/src/external/PiafMunch/PiafMunch2.cpp
+++ b/src/external/PiafMunch/PiafMunch2.cpp
@@ -61,7 +61,8 @@ double * vol_Sympl_dot = NULL ; // (ml / h) Variation rate of lateral parenchyma
 
 /******************* VARIABLES INVOLVED in CARBON METABOLISM AND FLUXES *******************************  */
 // as components of function f argument double* y in the solving procedure, the first 3 are stored as double* ; all others are Fortran_vectors
-double* Q_out = NULL;
+double* Q_Mucil = NULL;
+double* Q_S_ST = NULL;
 double* Q_Mesophyll = NULL						; // Amount of sugar in parenchyma symplasm										(mmol)
 double* Q_ST = NULL						; // Amount of sugar in sieve tubes	= C_TC * Vol_ST						(mmol)
 double* Q_RespMaint = NULL						; // Amount of starch in parenchyma										(mmol)
@@ -90,7 +91,7 @@ double Q_Rm_dot_alt ; // for an alternate, target-oriented,  expression of starc
 double* TracerQ_Mesophyll = NULL						; // Amount of tracer in parenchyma										(MBq)
 double* Q_RespMaintmax = NULL						; // Amount of soluble tracer in sieve tubes	= TracerC_ST * Vol_ST						(MBq)
 double* TracerQ_RespMaint = NULL						; // Amount of insoluble tracer in parenchyma										(MBq)
-double *Q_Exudationmax=NULL, *Q_Growthtotmax=NULL ; // Amount of soluble tracer in apoplasm	= TracerC_xxxApo * Vol_xxxApo			(MBq)
+double *Q_S_Mesophyll=NULL, *Q_Growthtotmax=NULL ; // Amount of soluble tracer in apoplasm	= TracerC_xxxApo * Vol_xxxApo			(MBq)
 Fortran_vector TracerJS_ST						; // TracerJS_ST[i] (MBq / h)  = TracerJS_ST_[i-1], i = 2..N  : Axial phloem soluble tracer flux ; TracerJS_ST[1]= NA, whereas TracerJS_ST_[1] = TracerJS_ST[2]
 Fortran_vector TracerJS_PhlMb						; // Lateral (Apoplasmic) soluble tracer fluxes into sieve tubes from parenchyma				(MBq / h)
 Fortran_vector TracerRespMaint					; // Tracer Maintenance respiration rate										(MBq / h)
@@ -107,8 +108,8 @@ Fortran_vector TracerC_SymplUpflow					;  // upflow tracer concentration (mmol /
 Fortran_vector TracerC_ApoUpflow ;				; // upflow tracer concentration (mmol / ml) for TracerJS_Apo
 
 /******* variation rate of any variable X is noted: X_dot = dX/dt : *******/
-double * Q_Mesophyll_dot = NULL, * Q_ST_dot = NULL, * Q_Rm_dot = NULL, *Q_Exud_dot = NULL, *Q_Gtot_dot = NULL,  *Q_out_dot = NULL  ;
-double * TracerQ_Mesophyll_dot=NULL, * Q_Rmmax_dot=NULL, * TracerQ_Rm_dot=NULL, *Q_Exudmax_dot=NULL, *Q_Gtotmax_dot=NULL ;
+double * Q_Mesophyll_dot = NULL, * Q_ST_dot = NULL, * Q_Rm_dot = NULL, *Q_Exud_dot = NULL, *Q_Gtot_dot = NULL,  *Q_S_ST_dot = NULL , *Q_Mucil_dot = NULL ;
+double * TracerQ_Mesophyll_dot=NULL, * Q_Rmmax_dot=NULL, * TracerQ_Rm_dot=NULL, *Q_S_Mesophyll_dot=NULL, *Q_Gtotmax_dot=NULL ;
 // Next 2 variables are not considered as such, but as possible inputs to compute vol_Sympl_dot :
 Fortran_vector P_ST_dot, P_Sympl_dot			; //  dP_ST/dt , dP_Sympl/dt					(MPa h / h)    -- for elasticity...
 
@@ -151,25 +152,65 @@ void PhloemFlux::C_fluxes(double t, int Nt)
 	TairC = TairK_phloem - 273.15;
 	for (int i = 1 ; i <= Nt ; i++) 
 	{ // edit (make different loops) to enter specific equations for specific nodes or conn.orders
+		int cpp_id = i -1;// o go from Fortran_vector numeration to cpp vector numeration
 		double CSTi = max(0.,C_ST[i]);// From A.Lacointe: solver may try C<0 even if actual C never does
 		double Cmeso = max(0.,Q_Mesophyll[i]/vol_ParApo[i]);//concentration in meosphyll compartment
 		//Q_Fl[i] = k_meso*max(Cmeso - CSTi, 0.);//flux from mesophyll to sieve tube
 		 
 		double Q_Rmmax_ ;double Q_Exudmax_;double Fu_lim;
-		Q_out_dot[i] = 0;// not used currently
+        
+		//starch		
+			//ST	
+		//Q_S_ST_dot[i] = 0;
+		double denominator = kM_S_ST + CSTi;
+		double StarchSyn = 0;
+		if(denominator != 0)
+		{
+			StarchSyn = Vmax_S_ST * max(0.,Q_ST[i]) / (denominator) ; //  (Vmax and kHyd below) or k3 (below),  or all three, should be zero
+		}
+		Q_Mucil_dot[i] = std::max(0.,k_mucil_[cpp_id] *   Q_S_ST[i]);//mucilage exudation
+		//an alternate, target-oriented,  expression of starch variation rate, mutually exclusive of (AmSyn - kHyd * Amid), so that...
+        double Starch_dot_alt = k_S_ST * (CSTi - C_targ) * vol_ST[i] ;	
+		Q_S_ST_dot[i] = StarchSyn + Starch_dot_alt - kHyd_S_ST *std::max(0., Q_S_ST[i]) ; // (Vmax and kHyd) or k3 (below),  or all three, should be zero
+		
+        if((Q_S_ST[i] <= 0.) && (Q_S_ST_dot[i] < 0.)) { // control negative starch concentrations (remove 4-lines-block if not relevant)
+            //cout << "at t=" << t << ", node#" << i << ": Starch <= 0 and Starch_dot < 0  =>  Starch_dot set to zero" << endl ;
+            Q_S_ST_dot[i] = 0. ;
+			Q_Mucil_dot[i] = 0. ;
+        }
+        double st_2_starch = Q_S_ST_dot[i] ;//+ Q_Mucil_dot[i];
+		Q_S_ST_dot[i] -=  Q_Mucil_dot[i];
+		
+        	//MEsophyll
+		Q_S_Mesophyll_dot[i] = 0.;
+        if(vol_ParApo[i]>0) {
+            denominator = kM_S_Mesophyll + Cmeso;
+            StarchSyn = 0;
+            if(denominator != 0)
+            {
+                StarchSyn = Vmax_S_Mesophyll * max(0.,Q_Mesophyll[i]) /  (denominator) ; //  (Vmax and kHyd below) or k3 (below),  or all three, should be zero
+            }
+            //an alternate, target-oriented,  expression of starch variation rate, mutually exclusive of (AmSyn - kHyd * Amid), so that...
+            Starch_dot_alt = k_S_Mesophyll * (Cmeso - C_targMesophyll) * vol_ParApo[i] ;	
+            Q_S_Mesophyll_dot[i] = StarchSyn - kHyd_S_Mesophyll * Q_S_Mesophyll[i] + Starch_dot_alt ; // (Vmax and kHyd) or k3 (below),  or all three, should be zero
+            if((Q_S_Mesophyll[i] <= 0.) && (Q_S_Mesophyll_dot[i] < 0.)) { // control negative starch concentrations (remove 4-lines-block if not relevant)
+                //cout << "at t=" << t << ", node#" << i << ": Starch <= 0 and Starch_dot < 0  =>  Starch_dot set to zero" << endl ;
+                Q_S_Mesophyll_dot[i] = 0. ;
+            }
+        }
 		
 		Q_Fl[i] = (Vmaxloading *len_leaf[i])* Cmeso/(Mloading + Cmeso) * exp(-CSTi* beta_loading);//phloem loading. from Stanfield&Bartlett_2022
 		CSTi = max(0., CSTi-CSTimin); //if CSTi < CSTimin, no sucrose usage
 		
-		double CSTi_delta = max(0.,CSTi-Csoil); //concentration gradient for passive exudation. TODO: take Csoil from dumux 
+		double CSTi_delta = max(0.,CSTi-Csoil_node[cpp_id]); //concentration gradient for passive exudation. TODO: take Csoil from dumux 
 		Q_Rmmax_ = (Q_Rmmax[i] + krm2[i] * CSTi) * pow(Q10,(TairC - TrefQ10)/10);//max maintenance respiration rate
 		
 		Q_Exudmax_ = CSTi_delta*Q_Exudmax[i];//max exudation rate
 		Fu_lim = (Q_Rmmax_  + Q_Grmax[i])* (CSTi/(CSTi + KMfu));//active transport of sucrose out of sieve tube			
-		Q_ST_dot[i] = Q_Fl[i] - Fu_lim -Q_Exudmax_ + Delta_JS_ST[i];//variation of sucrose content in node
+		Q_ST_dot[i] = Q_Fl[i] - Fu_lim -Q_Exudmax_ + Delta_JS_ST[i] - st_2_starch;//variation of sucrose content in node
 		
 		//Q_meso_dot:
-		Q_Mesophyll_dot[i] = Ag[i] -Q_Fl[i];//variaiton of sucrose content in mesophyll compartment 
+		Q_Mesophyll_dot[i] = Ag[i] -Q_Fl[i] - Q_S_Mesophyll_dot[i] ;//variaiton of sucrose content in mesophyll compartment 
 		
 		Input[i] = Q_Fl[i];//phloem loading
 		
@@ -187,16 +228,16 @@ void PhloemFlux::C_fluxes(double t, int Nt)
 		Q_Rmmax_dot[i] = Q_Rmmax_ ;
 		//Growthmax:
 		Q_Gtotmax_dot[i] = Q_Grmax[i];
-		//Exudationmax:
-		Q_Exudmax_dot[i] = Q_Exudmax[i];;
+				 
+								   
 		
 		if(doTroubleshooting){
 			std::cout<<"C_fluxes "<<i<<" "<<vol_ST[i]<<" "<<vol_ParApo[i]<<" "<<vol_Seg[i]<<" CSTimin "<<CSTimin<<std::endl;
 			std::cout<<"max(0.,C_ST[i]) "<<max(0.,C_ST[i])<<std::endl;
 			std::cout<<" C_ST[i] "<<C_ST[i]<<" Q_ST[i] "<<Q_ST[i]<<" "<<Q_Fl[i]<<" "<<CSTi<<" "<<Cmeso<<" "<<len_leaf[i]<<" max(0., CSTi-CSTimin) "<< max(0., CSTi-CSTimin)<<std::endl;
-			std::cout<<Q_Rmmax_<<" "<<Q_Rmmax[i]<<" "<< krm2[i]<<" "<<CSTi_delta<<" "<<Q_Exudmax[i]<<std::endl;
+			std::cout<<Q_Rmmax_<<" "<<Q_Rmmax[i]<<" "<< krm2[i]<<" "<<CSTi_delta<<std::endl;
 			std::cout<<Q_Exudmax_<<" Fu_lim "<<Fu_lim<<" Q_ST_dot "<<Q_ST_dot[i]<<" "<<Q_Mesophyll_dot[i]<<" "<<Input[i]<<" "<<Q_Rm_dot[i]<<std::endl;
-			std::cout<<"Qgri "<<Q_Gtot_dot[i] <<" Q_Exudmax_ "<<Q_Exud_dot[i]<<" Q_Rmmax_ "<<Q_Rmmax_dot[i]<<" Qgrmaxi "<<Q_Gtotmax_dot[i]<<" "<<Q_Exudmax_dot[i]<<std::endl;
+			std::cout<<"Qgri "<<Q_Gtot_dot[i] <<" Q_Exudmax_ "<<Q_Exud_dot[i]<<" Q_Rmmax_ "<<Q_Rmmax_dot[i]<<" Qgrmaxi "<<Q_Gtotmax_dot[i]<<std::endl;
 			std::cout<<"Qmeso "<<Q_Mesophyll[i]<<" "<<Ag[i]<<std::endl;
 		}
 		

--- a/src/external/PiafMunch/runPM.cpp
+++ b/src/external/PiafMunch/runPM.cpp
@@ -75,16 +75,16 @@ string AllNodeVariablesNamesQList[] = {
 	"P_ST_dot (MPa / h)", "P_Sympl_dot (MPa / h)", "Q_Rm_dot (mmol eq. Glu / h)", "Q_ST_dot (mmol / h)", "Q_Mesophyll_dot (mmol / h)", "Input (mmol / h)", "Transpirat (ml / h)", "PsiSoil (MPa)",
 // Tracer-specific add-ins :
 	"TracerQ_RespMaint (MBq)", "TracerQ_RespMaintSyn (MBq / h)", "TracerC_ST (MBq / ml)", "TracerC_Sympl (MBq / ml)", "TracerJS_PhlMb (MBq / h)", "TracerQ_Mesophyll (MBq)", "Q_RespMaintmax (MBq)", "TracerRespMaint (MBq / h)",
-	"TracerInput (MBq / h)", "TracerJS_Sympl (MBq / h)", "TracerJS_ParMb (MBq / h)", "Q_Exudationmax (MBq)", "Q_Growthtotmax (MBq)", "TracerC_PhlApo (MBq / ml)",
+	"TracerInput (MBq / h)", "TracerJS_Sympl (MBq / h)", "TracerJS_ParMb (MBq / h)", "Q_S_Mesophyll (MBq)", "Q_Growthtotmax (MBq)", "TracerC_PhlApo (MBq / ml)",
 	"TracerC_ParApo (MBq / ml)", "TracerJS_Apo (MBq / h)", "TracerC_SymplUpflow (MBq / ml)", "TracerC_ApoUpflow (MBq / ml)"
 } ;
 int NumAllConnVariablesNames = 5 ; // 5 internode connector flux variables :
 string AllConnVariablesNamesQList[] = { "C_Upflow (mmol / ml)", "JS_ST (mmol / h)", "JW_ST (ml / h)", "JW_Xyl (ml / h)", "TracerJS_ST (MBq / h)" } ;
 
-extern double *Q_ST, *Q_Mesophyll, *Q_RespMaint, *Q_Exudation, *Q_Growthtot, *Q_out ;		  // components of vector y as used in diff. system f()...
-extern double *Q_ST_dot, *Q_Mesophyll_dot, *Q_Rm_dot, *Q_Exud_dot, *Q_Gtot_dot, *Q_out_dot ; //... and its derivatives.  ;
-extern double *Q_RespMaintmax, *TracerQ_Mesophyll, *TracerQ_RespMaint, *Q_Exudationmax, *Q_Growthtotmax ;		  // components of vector y as used in diff. system f()...
-extern double *Q_Rmmax_dot, *TracerQ_Mesophyll_dot, *TracerQ_Rm_dot, *Q_Exudmax_dot, *Q_Gtotmax_dot ; //... and its derivatives.  ;
+extern double *Q_ST, *Q_Mesophyll, *Q_RespMaint, *Q_Exudation, *Q_Growthtot, *Q_S_ST, *Q_Mucil ;		  // components of vector y as used in diff. system f()...
+extern double *Q_ST_dot, *Q_Mesophyll_dot, *Q_Rm_dot, *Q_Exud_dot, *Q_Gtot_dot, *Q_S_ST_dot, *Q_Mucil_dot ; //... and its derivatives.  ;
+extern double *Q_RespMaintmax, *TracerQ_Mesophyll, *TracerQ_RespMaint, *Q_S_Mesophyll, *Q_Growthtotmax ;		  // components of vector y as used in diff. system f()...
+extern double *Q_Rmmax_dot, *TracerQ_Mesophyll_dot, *TracerQ_Rm_dot, *Q_S_Mesophyll_dot, *Q_Gtotmax_dot ; //... and its derivatives.  ;
 extern double *vol_Sympl, *vol_Sympl_dot ;
 extern Fortran_vector Psi_Xyl, JW_ST, JS_ST, C_Sympl, C_ST, C_amont, JS_Sympl, JS_Apo, JS_ParMb, JS_PhlMb, Psi_Sympl, C_PhlApo, C_ParApo, P_ST, Absorb, RespMaint ;
 extern Fortran_vector JW_Trsv, JW_Xyl, JW_PhlMb, JW_ParMb, JW_Apo, JW_Sympl, P_Sympl, Psi_ST, P_Xyl, Psi_PhlApo, Psi_ParApo, P_PhlApo, P_ParApo ;
@@ -118,8 +118,8 @@ Fortran_matrix JW_ST_t, JS_ST_t, C_Sympl_t, C_ST_t, JS_Sympl_t, JS_Apo_t, JS_Par
 Fortran_matrix JW_Trsv_t, JW_Xyl_t, JW_PhlMb_t, JW_ParMb_t, JW_Apo_t, JW_Sympl_t, P_Sympl_t, Psi_ST_t, P_Xyl_t, Psi_PhlApo_t, Psi_ParApo_t, P_PhlApo_t, P_ParApo_t ;
 Fortran_matrix PsiSoil_t, Transpirat_t, Input_t, Q_RespMaintSyn_t, P_ST_dot_t, P_Sympl_dot_t, C_SymplUpflow_t, C_ApoUpflow_t, C_amont_t ;
 // tracer-specific add-ins :
-Fortran_matrix Q_RespMaintmax_t, TracerQ_Mesophyll_t, TracerQ_RespMaint_t, Q_Exudationmax_t, Q_Growthtotmax_t ;		  // components of vector y as used in diff. system f()...
-// Fortran_matrix Q_Rmmax_dot_t, TracerQ_Mesophyll_dot_t, TracerQ_Rm_dot_t, Q_Exudmax_dot_t, Q_Gtotmax_dot_t ;		  // components of vector y as used in diff. system f()...
+Fortran_matrix Q_RespMaintmax_t, TracerQ_Mesophyll_t, TracerQ_RespMaint_t, Q_S_Mesophyll_t, Q_Growthtotmax_t ;		  // components of vector y as used in diff. system f()...
+// Fortran_matrix Q_Rmmax_dot_t, TracerQ_Mesophyll_dot_t, TracerQ_Rm_dot_t, Q_S_Mesophyll_dot_t, Q_Gtotmax_dot_t ;		  // components of vector y as used in diff. system f()...
 Fortran_matrix TracerJS_ST_t, TracerC_Sympl_t, TracerC_ST_t, TracerJS_Sympl_t, TracerJS_Apo_t, TracerJS_ParMb_t, TracerJS_PhlMb_t, TracerC_PhlApo_t, TracerC_ParApo_t, TracerC_SymplUpflow_t, TracerC_ApoUpflow_t ;
 Fortran_matrix TracerPhotSynth_t, TracerQ_RespMaintSyn_t, TracerInput_t, TracerRespMaint_t ;
 // Fortran_matrix TracerRatioSympl_t, TracerRatioQ_RespMaint_t ;
@@ -132,7 +132,7 @@ Fortran_matrix* AllNodeMatricesRefsQList[] = {
 	&P_ST_dot_t, &P_Sympl_dot_t, &Q_Rm_dot_t, &Q_ST_dot_t, &Q_Mesophyll_dot_t, &Input_t, &Transpirat_t, &PsiSoil_t,
 	// tracer-specific add-ons :
 	&TracerQ_RespMaint_t, &TracerQ_RespMaintSyn_t, &TracerC_ST_t, &TracerC_Sympl_t, &TracerJS_PhlMb_t, &TracerQ_Mesophyll_t, &Q_RespMaintmax_t, &TracerRespMaint_t,
-	&TracerInput_t, &TracerJS_Sympl_t, &TracerJS_ParMb_t, &Q_Exudationmax_t, &Q_Growthtotmax_t, &TracerC_PhlApo_t,
+	&TracerInput_t, &TracerJS_Sympl_t, &TracerJS_ParMb_t, &Q_S_Mesophyll_t, &Q_Growthtotmax_t, &TracerC_PhlApo_t,
 	&TracerC_ParApo_t, &TracerJS_Apo_t, &TracerC_SymplUpflow_t, &TracerC_ApoUpflow_t
 };
 Fortran_matrix* AllConnMatricesRefsQList[] = {&C_amont_t, &JS_ST_t,  &JW_ST_t, &JW_Xyl_t, &TracerJS_ST_t} ;
@@ -364,13 +364,14 @@ void PhloemFlux::initializePM_(double dt, double TairK){
 	vol_Seg=Fortran_vector(Nt, 0.);//for postprocessing	
 	exud_k=Fortran_vector(Nt, 0.);
 	krm2=Fortran_vector(Nt, 0.);
+	Csoil_node.resize(Nt,0.);
 	deltaSucOrgNode_ = waterLimitedGrowth(dt);//water limited growth
 	if(doTroubleshooting){cout<<"initializePM_new "<<Nc<<" "<<Nt<<endl;}
 	int nodeID;
 	double StructSucrose;//double deltaStructSucrose;
 	double cmH2O_to_hPa = 0.980638	;//cm to hPa
 	double krm1;
-	
+	k_mucil_.resize(Nt , 0.);
 	if(psiXyl4Phloem.size() == Nt){Psi_Xyl = Fortran_vector(psiXyl4Phloem,cmH2O_to_hPa); //computed by xylem object
 	}else{Psi_Xyl = Fortran_vector(Nt, 0.);}
 	
@@ -397,10 +398,13 @@ void PhloemFlux::initializePM_(double dt, double TairK){
 	
 	for ( int k=1 ;k <= Nc;k++ ) 
 	{
+			//the PiafMunch Fortran_vector are numbered from 1 (and not from 0)
+			//so we need to account for that...
+			// element 0 contains the vector size i think
 			ot = orgTypes[k-1]; st = subTypes[k-1];
 			a_seg = Radii[k-1];
 			l = Lengthvec[k-1];
-			I_Upflow[k] = segmentsPlant[k-1].x +1;
+			I_Upflow[k] = segmentsPlant[k-1].x +1;// +1 to go from C++ numeration to pseudo-Fortran numeration
 			I_Downflow[k] = segmentsPlant[k-1].y +1;
 			
 			nodeID = I_Downflow[k];
@@ -424,8 +428,20 @@ void PhloemFlux::initializePM_(double dt, double TairK){
 			//Exudation
 			exud_k[nodeID] =kr_st_f(st,ot, k-1);
 			Q_Exudmax[nodeID ]=0;
-			if(ot==2){
+			if((ot==2)&&(this->plant->seg2cell[k-1] >=0)){//root segment belowground
 				Q_Exudmax[nodeID ] =   2 * M_PI * a_seg * l*exud_k[nodeID] ;
+				if (exud_k[nodeID] > 0.)
+				{
+					// k_mucil is a std::vecto not a fotran vector
+					k_mucil_[segmentsPlant[k-1].y ] = k_mucil;
+				}
+				if(Csoil_seg.size() > 0.)
+				{
+					// Csoil_node is a std::vecto not a fotran vector
+					Csoil_node.at(segmentsPlant[k-1].y ) = Csoil_seg.at(k -1);					
+				}else{
+					Csoil_node.at(segmentsPlant[k-1].y ) = CsoilDefault;
+				}
 			}
 			if(doTroubleshooting){std::cout<<"QexudMax "<<Q_Exudmax[nodeID ]<<std::endl;}
 			
@@ -895,7 +911,7 @@ std::vector<std::map<int,double>> PhloemFlux::waterLimitedGrowth(double t)
                     if((StemGrowthPerPhytomer)&&(org->getNumberOfChildren() > 0))
                     {
                         
-                        
+						
                         auto stemParams = std::static_pointer_cast<CPlantBox::Stem>(org)->param();
                         int PhytoIdx = 0; bool foundPhytoIdx = false;
                        if(doTroubleshooting){
@@ -1116,157 +1132,227 @@ std::vector<std::map<int,double>> PhloemFlux::waterLimitedGrowth(double t)
  * @param kr_length_ 	exchange zone in root, where kr > 0 [cm from root tip], default = -1.0, i.e., no kr_length
  */
 //type/subtype dependent
-void PhloemFlux::setKr_st(std::vector<std::vector<double>> values, double kr_length_) {
+void PhloemFlux::setKr_st(std::vector<std::vector<double>> values, double kr_length_, bool verbose) {
     kr_st = values;
 	if (values.size()==1) {
 		if (values[0].size()==1) {
 			kr_st_f = std::bind(&PhloemFlux::kr_st_const, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-			std::cout << "Kr_st is constant " << values[0][0] << " 1 day-1 \n";
+            if (verbose)
+            {
+                std::cout << "Kr_st is constant " << values[0][0] << " 1 day-1 \n";
+            }
 		} 
 	} else {
 		if (values[0].size()==1) {
 			kr_st_f = std::bind(&PhloemFlux::kr_st_perOrgType, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-			std::cout << "Kr_st is constant per organ type, organ type 2 (root) = " << values[0][0] << " 1 day-1 \n";
+			if (verbose)
+            {
+                std::cout << "Kr_st is constant per organ type, organ type 2 (root) = " << values[0][0] << " 1 day-1 \n";
+            }
 		} else {
-			std::cout << "Exchange zone in roots: kr_st > 0 until "<< kr_length_<<"cm from root tip "<<(kr_length_ > 0)<<" "<<(kr_length_ > 0.)<<std::endl;
+			if (verbose)
+            {
+                std::cout << "Exchange zone in roots: kr_st > 0 until "<< kr_length_<<"cm from root tip "<<(kr_length_ > 0)<<" "<<(kr_length_ > 0.)<<std::endl;
+            }
 			if(kr_length_ > 0.){
-				std::cout << "Exchange zone in roots: kr > 0 until "<< kr_length_<<"cm from root tip"<<std::endl;
+				if (verbose)
+            {
+                std::cout << "Exchange zone in roots: kr > 0 until "<< kr_length_<<"cm from root tip"<<std::endl;
+                }
 				plant->kr_length = kr_length_; //in MappedPlant. define distance to root tipe where kr > 0 as cannot compute distance from age in case of carbon-limited growth
 				plant->calcExchangeZoneCoefs();	
 				kr_st_f  = std::bind(&PhloemFlux::kr_st_RootExchangeZonePerType, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
 			}else{
 				kr_st_f  = std::bind(&PhloemFlux::kr_st_perType, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
 			}
-			std::cout << "Kr_st is constant per subtype of organ type, for root, subtype 1 = " << values[0].at(1) << " 1 day-1 \n";
+			if (verbose)
+            {
+                std::cout << "Kr_st is constant per subtype of organ type, for root, subtype 1 = " << values[0].at(1) << " 1 day-1 \n";
+            }
 		}
 	}
     
 }	
 // type/subtype dependent
-void PhloemFlux::setKx_st(std::vector<std::vector<double>> values) {
+void PhloemFlux::setKx_st(std::vector<std::vector<double>> values, bool verbose) {
     kx_st = values;
 	if (values.size()==1) {
 		if (values[0].size()==1) {
 			kx_st_f = std::bind(&PhloemFlux::kx_st_const, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "Kx_st is constant " << values[0][0] << " cm3 day-1 \n";
+			if (verbose)
+            {
+                std::cout << "Kx_st is constant " << values[0][0] << " cm3 day-1 \n";
+            }
 		} 
 	} else {
 		if (values[0].size()==1) {
 			kx_st_f = std::bind(&PhloemFlux::kx_st_perOrgType, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "Kx_st is constant per organ type, organ type 2 (root) = " << values[0][0] << " cm3 day-1 \n";
+			if (verbose)
+            {
+                std::cout << "Kx_st is constant per organ type, organ type 2 (root) = " << values[0][0] << " cm3 day-1 \n";
+            }
 		} else {
 			kx_st_f  = std::bind(&PhloemFlux::kx_st_perType, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "Kx_st is constant per subtype of organ type, for root, subtype 1 = " << values[0].at(1) << " cm3 day-1 \n";
+			if (verbose)
+            {
+                std::cout << "Kx_st is constant per subtype of organ type, for root, subtype 1 = " << values[0].at(1) << " cm3 day-1 \n";
+            }
 		}
 	}
 }	
 
 
 //type/subtype dependent
-void PhloemFlux::setAcross_st(std::vector<std::vector<double>> values) {
+void PhloemFlux::setAcross_st(std::vector<std::vector<double>> values, bool verbose) {
     Across_st = values;
 	if (values.size()==1) {
 		if (values[0].size()==1) {
 			Across_st_f = std::bind(&PhloemFlux::Across_st_const, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "Across_st is constant " << values[0][0] << " cm2\n";
+			if (verbose)
+            {
+                std::cout << "Across_st is constant " << values[0][0] << " cm2\n";
+            }
 		} 
 	} else {
 		if (values[0].size()==1) {
 			Across_st_f = std::bind(&PhloemFlux::Across_st_perOrgType, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "Across_st is constant per organ type, organ type 2 (root) = " << values[0][0] << " cm2 \n";
+			if (verbose)
+            {
+                std::cout << "Across_st is constant per organ type, organ type 2 (root) = " << values[0][0] << " cm2 \n";
+            }
 		} else {
 			Across_st_f  = std::bind(&PhloemFlux::Across_st_perType, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "Across_st is constant per subtype of organ type, for root, subtype 1 = " << values[0].at(1) << " cm2 \n";
+			if (verbose)
+            {
+                std::cout << "Across_st is constant per subtype of organ type, for root, subtype 1 = " << values[0].at(1) << " cm2 \n";
+            }
 		}
 	}
 }	
 
 
 //type/subtype dependent ==> to compute Rhat Fhat
-void PhloemFlux::setPerimeter_st(std::vector<std::vector<double>> values) {
+void PhloemFlux::setPerimeter_st(std::vector<std::vector<double>> values, bool verbose) {
     Perimeter_st = values;
 	if (values.size()==1) {
 		if (values[0].size()==1) {
 			Perimeter_st_f = std::bind(&PhloemFlux::Perimeter_st_const, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "Perimeter_st is constant " << values[0][0] << " cm\n";
+			if (verbose)
+            {
+                std::cout << "Perimeter_st is constant " << values[0][0] << " cm\n";
+            }
 		} 
 	} else {
 		if (values[0].size()==1) {
 			Perimeter_st_f = std::bind(&PhloemFlux::Perimeter_st_perOrgType, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "Perimeter_st is constant per organ type, organ type 2 (root) = " << values[0][0] << " cm\n";
+			if (verbose)
+            {
+                std::cout << "Perimeter_st is constant per organ type, organ type 2 (root) = " << values[0][0] << " cm\n";
+            }
 		} else {
 			Perimeter_st_f  = std::bind(&PhloemFlux::Perimeter_st_perType, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "Perimeter_st is constant per subtype of organ type, for root, subtype 1 = " << values[0].at(1) << " cm\n";
+			if (verbose)
+            {
+                std::cout << "Perimeter_st is constant per subtype of organ type, for root, subtype 1 = " << values[0].at(1) << " cm\n";
+            }
 		}
 	}
 }	
 
 // type/subtype dependent
-void PhloemFlux::setRmax_st(std::vector<std::vector<double>> values) {
+void PhloemFlux::setRmax_st(std::vector<std::vector<double>> values, bool verbose) {
     Rmax_st = values;
 	if (values.size()==1) {
 		if (values[0].size()==1) {
 			Rmax_st_f = std::bind(&PhloemFlux::Rmax_st_const, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "Rmax_st is constant " << values[0][0] << " cm day-1 \n";
+			if (verbose)
+            {
+                std::cout << "Rmax_st is constant " << values[0][0] << " cm day-1 \n";
+            }
 		} 
 	} else {
 		if (values[0].size()==1) {
 			Rmax_st_f = std::bind(&PhloemFlux::Rmax_st_perOrgType, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "Rmax_st is constant per organ type, organ type 2 (root) = " << values[0][0] << " cm day-1 \n";
+			if (verbose)
+            {
+                std::cout << "Rmax_st is constant per organ type, organ type 2 (root) = " << values[0][0] << " cm day-1 \n";
+            }
 		} else {
 			Rmax_st_f  = std::bind(&PhloemFlux::Rmax_st_perType, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "Rmax_st is constant per subtype of organ type, for root, subtype 1 = " << values[0].at(1) << " cm day-1 \n";
+			if (verbose)
+            {
+                std::cout << "Rmax_st is constant per subtype of organ type, for root, subtype 1 = " << values[0].at(1) << " cm day-1 \n";
+            }
 		}
 	}
 }	
 
 
 //either age or type/subtype dependent
-void PhloemFlux::setRhoSucrose(std::vector<std::vector<double>> values) {
+void PhloemFlux::setRhoSucrose(std::vector<std::vector<double>> values, bool verbose) {
     rhoSucrose = values;
 	if (values.size()==1) {
 		if (values[0].size()==1) {
 			rhoSucrose_f = std::bind(&PhloemFlux::rhoSucrose_const, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "rhoSucrose is constant " << values[0][0] << " mmol cm-3\n";
+			if (verbose)
+            {
+                std::cout << "rhoSucrose is constant " << values[0][0] << " mmol cm-3\n";
+            }
 		} 
 	} else {
 		if (values[0].size()==1) {
 			rhoSucrose_f = std::bind(&PhloemFlux::rhoSucrose_perOrgType, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "rhoSucrose is constant per organ type, organ type 2 (root) = " << values[0][0] << " mmol cm-3\n";
+			if (verbose)
+            {
+                std::cout << "rhoSucrose is constant per organ type, organ type 2 (root) = " << values[0][0] << " mmol cm-3\n";}
 		} else {
 			rhoSucrose_f  = std::bind(&PhloemFlux::rhoSucrose_perType, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "rhoSucrose is constant per subtype of organ type, for root, subtype 1 = " << values[0].at(1) << " mmol cm-3\n";
+			if (verbose)
+            {
+                std::cout << "rhoSucrose is constant per subtype of organ type, for root, subtype 1 = " << values[0].at(1) << " mmol cm-3\n";}
 		}
 	}
 }	
 
 
 //either age or type/subtype dependent
-void PhloemFlux::setKrm1(std::vector<std::vector<double>> values) {
+void PhloemFlux::setKrm1(std::vector<std::vector<double>> values, bool verbose) {
     krm1v = values;
 	if (values.size()==1) {
 		if (values[0].size()==1) {
 			krm1_f = std::bind(&PhloemFlux::krm1_const, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "krm1 is constant " << values[0][0] << " -\n";
+			if (verbose)
+            {
+                std::cout << "krm1 is constant " << values[0][0] << " -\n";
+            }
 		} 
 	} else {
 		if (values[0].size()==1) {
 			krm1_f = std::bind(&PhloemFlux::krm1_perOrgType, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "krm1 is constant per organ type, organ type 2 (root) = " << values[0][0] << " -\n";
+			if (verbose)
+            {
+                std::cout << "krm1 is constant per organ type, organ type 2 (root) = " << values[0][0] << " -\n";
+            }
 		} else {
 			krm1_f  = std::bind(&PhloemFlux::krm1_perType, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "krm1 is constant per subtype of organ type, for root, subtype 1 = " << values[0].at(1) << "-\n";
+			if (verbose)
+            {
+                std::cout << "krm1 is constant per subtype of organ type, for root, subtype 1 = " << values[0].at(1) << "-\n";
+            }
 		}
 	}
 }	
 
 //either age or type/subtype dependent
-void PhloemFlux::setKrm2(std::vector<std::vector<double>> values) {
+void PhloemFlux::setKrm2(std::vector<std::vector<double>> values, bool verbose) {
     krm2v = values;
 	if (values.size()==1) {
 		if (values[0].size()==1) {
 			krm2_f = std::bind(&PhloemFlux::krm2_const, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "krm2 is constant " << values[0][0] << " -\n";
+			if (verbose)
+            {
+                std::cout << "krm2 is constant " << values[0][0] << " -\n";
+            }
 		} 
 	} else {
 		if (values[0].size()==1) {
@@ -1274,7 +1360,10 @@ void PhloemFlux::setKrm2(std::vector<std::vector<double>> values) {
 			std::cout << "krm2 is constant per organ type, organ type 2 (root) = " << values[0][0] << " -\n";
 		} else {
 			krm2_f  = std::bind(&PhloemFlux::krm2_perType, this, std::placeholders::_1, std::placeholders::_2);
-			std::cout << "krm2 is constant per subtype of organ type, for root, subtype 1 = " << values[0].at(1) << "-\n";
+			if (verbose)
+            {
+                std::cout << "krm2 is constant per subtype of organ type, for root, subtype 1 = " << values[0].at(1) << "-\n";
+            }
 		}
 	}
 }	

--- a/src/external/PiafMunch/solve.cpp
+++ b/src/external/PiafMunch/solve.cpp
@@ -102,8 +102,8 @@ void Smooth_Parameter_and_BoundaryConditions_Changes(int s, double t) ; // User-
 void vector_init(double t, double *y, double *y_dot);
 
 // ******************  mere C-fluxes related variables or parameters ********** :
-extern double *Q_ST, *Q_Mesophyll, *Q_RespMaint, *Q_Exudation, *Q_Growthtot, *Q_out ;		  // components of vector y as used in diff. system f()...
-extern double *Q_ST_dot, *Q_Mesophyll_dot, *Q_Rm_dot, *Q_Exud_dot, *Q_Gtot_dot, *Q_out_dot ; //... and its derivatives.  ;
+extern double *Q_ST, *Q_Mesophyll, *Q_RespMaint, *Q_Exudation, *Q_Growthtot, *Q_S_ST, *Q_Mucil ;		  // components of vector y as used in diff. system f()...
+extern double *Q_ST_dot, *Q_Mesophyll_dot, *Q_Rm_dot, *Q_Exud_dot, *Q_Gtot_dot, *Q_S_ST_dot, *Q_Mucil_dot ; //... and its derivatives.  ;
 extern double *vol_Sympl ;
 extern Fortran_vector JS_ST, C_amont, JS_Sympl, JS_Apo, RespMaint ;
 extern Fortran_vector vol_ST, vol_PhlApo, vol_ParApo ;
@@ -121,8 +121,8 @@ extern Fortran_vector C_Sympl, C_ParApo		; // Concentration of sugar in lateral 
 extern Fortran_vector Delta_JS_ST ; // sera la composante purement phloemienne de Q_TC_dot[ ]							(mmol / h)
 
 // tracer-specific add-ins :
-extern double *Q_RespMaintmax, *TracerQ_Mesophyll, *TracerQ_RespMaint, *Q_Exudationmax, *Q_Growthtotmax ;		  // components of vector y as used in diff. system f()...
-extern double *Q_Rmmax_dot, *TracerQ_Mesophyll_dot, *TracerQ_Rm_dot, *Q_Exudmax_dot, *Q_Gtotmax_dot ; //... and its derivatives.  ;
+extern double *Q_RespMaintmax, *TracerQ_Mesophyll, *TracerQ_RespMaint, *Q_S_Mesophyll, *Q_Growthtotmax ;		  // components of vector y as used in diff. system f()...
+extern double *Q_Rmmax_dot, *TracerQ_Mesophyll_dot, *TracerQ_Rm_dot, *Q_S_Mesophyll_dot, *Q_Gtotmax_dot ; //... and its derivatives.  ;
 extern Fortran_vector TracerJS_ST, TracerC_Sympl, TracerC_ST, TracerJS_Sympl, TracerJS_Apo, TracerJS_ParMb, TracerJS_PhlMb, TracerC_PhlApo, TracerC_ParApo ;
 extern Fortran_vector TracerQ_RespMaintSyn, TracerInput, TracerRespMaint, TracerC_SymplUpflow, TracerC_ApoUpflow ;
 extern Fortran_vector TracerRatioSympl, TracerRatioQ_RespMaint ;
@@ -200,10 +200,11 @@ void PhloemFlux::f(double t, double *y, double *y_dot) { // the function to be p
 	
 	Q_RespMaintmax = Q_Growthtot + Nt ; 
 	Q_Growthtotmax = Q_RespMaintmax + Nt ; 
-	Q_Exudationmax = Q_Growthtotmax + Nt ; 
+	Q_S_Mesophyll = Q_Growthtotmax + Nt ; 
 	
 	//if delete, lower neq
-	Q_out = Q_Exudationmax + Nt;//for intermediary compartment between ST and outside. useless (not implemented) delete?
+	Q_S_ST = Q_S_Mesophyll + Nt;
+	Q_Mucil = Q_S_ST + Nt ;
 	
 	for (int i=1; i<=Nt; i++)  {
 		double volSTi = vol_ST[i];
@@ -211,6 +212,8 @@ void PhloemFlux::f(double t, double *y, double *y_dot) { // the function to be p
 		
 		if (QSTi < 0.){ QSTi = 0. ; Q_ST[i] =0;}// fix any artefact from solver (may try C<0 even if actual C never does)
 		if (Q_Mesophyll[i] < 0.){ Q_Mesophyll[i] =0;}// fix any artefact from solver (may try C<0 even if actual C never does)
+		if (Q_S_ST[i] < 0.){ Q_S_ST[i] =0;}// fix any artefact from solver (may try C<0 even if actual C never does)
+		if (Q_S_Mesophyll[i] < 0.){ Q_S_Mesophyll[i] =0;}// fix any artefact from solver (may try C<0 even if actual C never does)
 		C_ST[i] = QSTi / volSTi ; // Concentration of sugar in sieve tubes		(mmol / ml)
 	
 	}
@@ -222,10 +225,11 @@ void PhloemFlux::f(double t, double *y, double *y_dot) { // the function to be p
 	
 	Q_Rmmax_dot = Q_Gtot_dot + Nt ; 
 	Q_Gtotmax_dot = Q_Rmmax_dot + Nt ; 
-	Q_Exudmax_dot = Q_Gtotmax_dot + Nt ; 
+	Q_S_Mesophyll_dot = Q_Gtotmax_dot + Nt ; 
 	
 	
-	Q_out_dot = Q_Exudmax_dot + Nt ;//useless, delete?
+	Q_S_ST_dot = Q_S_Mesophyll_dot + Nt ;
+	Q_Mucil_dot = Q_S_ST_dot + Nt ;
 	
 	//Add later
 	/*if (Adv_BioPhysics) {

--- a/src/functional/Photosynthesis.h
+++ b/src/functional/Photosynthesis.h
@@ -37,7 +37,7 @@ public:
 	void linearSystemSolve(double simTime_, const std::vector<double>& sxx_, bool cells_, 
 				const std::vector<double> soil_k_);///< main function, solves the flux equations
 	
-	void loopCalcs(double simTime); ///<solves photosynthesis/stomatal opening equations 
+	void loopCalcs(double simTime, std::vector<double> sxx_, bool cells_); ///<solves photosynthesis/stomatal opening equations 
 	void photoC4_loop(int i);
 	void photoC3_loop(int i);
 	//Compute variables which do not vary during one "solve_photosynthesis " computation
@@ -88,8 +88,8 @@ public:
     std::vector<double> Vcrefmax;
 	std::vector<double> Vj; //gross assimilation rate per unit of surface [mol CO2 m-2 s-1]
 	std::vector<double> ci;
-	std::vector<double> Jw;
-	std::vector<double> Ev;
+	std::vector<double> Jw;//transpiration [cm3 cm-2 d-1]
+	std::vector<double> Ev; //transpiration [cm3/day]
 	std::vector<double> PVD;
 	std::vector<double> EAL;
 	std::vector<double> hrelL;
@@ -162,6 +162,7 @@ public:
 	// 				C3 and C4
 	//water stress factor, parametrised from data of Corso2020
     double fwr = 9.308e-2; //residual opening when water stress parametrised with data from corso2020 [-]
+	double fw_cutoff = 0;// to make it easier to get fw
 	double sh = 3.765e-4;//sensibility to water stress
 	double p_lcrit = -15000/2;//min psiXil for stomatal opening [Mpa]
 	//influence of N contant, to reparametrise!, 
@@ -170,7 +171,7 @@ public:
 	double alpha = 0.2; //or 0.44 , coefb = -(alpha * Qlight + Jmax);, alpha * Qlight * Jmax;
 	double a1=4.; //g0+ fw[i] * a1 *( An[i] + Rd)/(ci[i] - deltagco2[i]);//tuzet2003
 	double g0 = 0.3e-3;//residual stomatal opening to CO2, Tuzet 2003 [mol CO2 m-2 s-1]
-	double gamma0 = 28e-6; double gamma1 = 0.0509; double gamma2 = 0.001;
+	//double gamma0 = 28e-6; double gamma1 = 0.0509; double gamma2 = 0.001;
 	
 	// 				C3 only
 	double a3 = 1.7;//Jrefmax = Vcrefmax * a3 ;//Eq 25
@@ -196,12 +197,13 @@ public:
 	// 				MOSTLY C3 (very small effect on C4)
 	//(de)activate parameters
     double Eac = 59430; double Eaj = 37000; double Eao = 36000;//mJ mmol-1
-    double Eard = 53000;double Eav = 58520;
+    double Eard = 53000;double Eav = 58520;double Ead = 37830;
     double Edj =  220000;double Edv = 220000;double Edrd;// = 53000;
 	//double Rd_refC3 = 0.32e-6; one less param!
 	double S = 700;//enthropy mJ mmol-1 K-1
 	//ref value at T = T_ref
 	double Kc_ref = 302e-6; double Ko_ref = 256e-3; //mmol mmol-1
+    double delta_ref= 42.75e-6;
 	
 	// 				C4 only
 	double s1 = 0.3; //K-1	Bonan2019Chap11: temperature

--- a/src/functional/XylemFlux.h
+++ b/src/functional/XylemFlux.h
@@ -38,22 +38,23 @@ public:
     std::vector<double> aV;
     std::vector<double> aB;
 
-    void setKr(std::vector<double> values, std::vector<double> age = std::vector<double>(0)); ///< sets a callback for kr:=kr(age,type),  [1 day-1]
-    void setKx(std::vector<double> values, std::vector<double> age = std::vector<double>(0)); ///< sets a callback for kx:=kx(age,type),  [cm3 day-1]
-    void setKrTables(std::vector<std::vector<double>> values, std::vector<std::vector<double>> age);
-    void setKxTables(std::vector<std::vector<double>> values, std::vector<std::vector<double>> age);
-    void setKr(std::vector<std::vector<double>> values, std::vector<std::vector<double>> age, double kr_length_ = -1.0); ///< sets a callback for kr:=kr(age,type),  [1 day-1]
-    void setKx(std::vector<std::vector<double>> values, std::vector<std::vector<double>> age); ///< sets a callback for kx:=kx(age,type),  [cm3 day-1]
-    void setKrTables(std::vector<std::vector<std::vector<double>>> values, std::vector<std::vector<std::vector<double>>> age);
-    void setKxTables(std::vector<std::vector<std::vector<double>>> values, std::vector<std::vector<std::vector<double>>> age);
-    void setKrValues(std::vector<double> values); ///< one value per segment
-    void setKxValues(std::vector<double> values); ///< one value per segment
+    void setKr(std::vector<double> values, std::vector<double> age = std::vector<double>(0), bool verbose = false); ///< sets a callback for kr:=kr(age,type),  [1 day-1]
+    void setKx(std::vector<double> values, std::vector<double> age = std::vector<double>(0), bool verbose = false); ///< sets a callback for kx:=kx(age,type),  [cm3 day-1]
+    void setKrTables(std::vector<std::vector<double>> values, std::vector<std::vector<double>> age, bool verbose = false, bool ageBased = true);
+    void setKxTables(std::vector<std::vector<double>> values, std::vector<std::vector<double>> age, bool verbose = false);
+    void setKr(std::vector<std::vector<double>> values, std::vector<std::vector<double>> age, double kr_length_ = -1.0, bool verbose = false); ///< sets a callback for kr:=kr(age,type),  [1 day-1]
+    void setKx(std::vector<std::vector<double>> values, std::vector<std::vector<double>> age, bool verbose = false); ///< sets a callback for kx:=kx(age,type),  [cm3 day-1]
+    void setKrTables(std::vector<std::vector<std::vector<double>>> values, std::vector<std::vector<std::vector<double>>> age, bool verbose, bool ageBased = true);
+    void setKxTables(std::vector<std::vector<std::vector<double>>> values, std::vector<std::vector<std::vector<double>>> age, bool verbose);
+    void setKrValues(std::vector<double> values, bool verbose = false); ///< one value per segment
+    void setKxValues(std::vector<double> values, bool verbose = false); ///< one value per segment
 
 
    std::function<double(int, double, int, int)> kr_f = [](int si, double age, int type, int orgtype){
 		throw std::runtime_error("kr_f not implemented"); return 0.; };
     std::function<double(int, double,int,int)> kx_f = [](int si, double age, int type, int orgtype) {
 		throw std::runtime_error("kx_f not implemented"); return 1.; };
+	double kr_f_wrapped(int si, double age, int type, int orgtype) const;///stops transpiration if organs are not in the correct domain
 
 	virtual size_t fillVectors(size_t k, int i, int j, double bi, double cii, double cij, double psi_s) ; ///< fill the vectors aI, aJ, aV, aB
 	virtual double getPsiOut(bool cells, int si, const std::vector<double>& sx_) const; ///< get the outer water potential [cm]
@@ -118,6 +119,18 @@ protected:
 		return kr.at(organType - 2).at(type);
 	} //subtype, type and depend on distance to tip for roots
 
+	double kr_tablePerType_distance(int si,double age, int type, int organType)//when use carbon- and water-limited growth, canNOT use "kr_tablePerType" instead of this function
+	{
+		 
+		if (organType == Organism::ot_root){
+			//double coef = rs->exchangeZoneCoefs.at(si);//% of segment length in the root exchange zone, see MappedPlant::simulate
+			double distFromTip = rs->distanceTip.at(si);//% of segment length in the root exchange zone, see MappedPlant::simulate 
+			
+			double kr_ = Function::interp1(distFromTip, krs_t.at(organType-2).at(type), krs.at(organType-2).at(type));
+			return kr_;//coef * kr.at(organType - 2).at(type);
+		}
+		return krs.at(organType - 2).at(type).at(0);
+	} //subtype, type and depend on distance to tip for roots
     double kx_const(int si,double age, int type, int organType) { return kx.at(0).at(0); } //k constant
     double kx_perOrgType(int si,double age, int type, int organType) { return kx.at(organType - 2)[0]; } //per organ type (goes from 2 (root) to 4 (leaf))
     double kx_perType(int si,double age, int type, int organType) { return kx.at(organType - 2).at(type); } //per subtype and organ type (goes from 2 (root) to 4 (leaf))

--- a/src/functional/phloem_flux.py
+++ b/src/functional/phloem_flux.py
@@ -18,7 +18,10 @@ class PhloemFluxPython(PhloemFlux):
     def __init__(self, plant_, psiXylInit, ciInit):
         """ @param rs is either a pb.MappedRootSystem, pb.MappedSegments, or a string containing a rsml filename"""
         super().__init__( plant_, psiXylInit, ciInit)
-
+        
+    def getPsiAir(self,RH, TairC):#constants are within photosynthesys.h
+        return np.log(RH) * self.rho_h2o * self.R_ph * (TairC + 237.3)/self.Mh2o * (1/0.9806806)  ; #in cm
+     
     def get_nodes(self):
         """ converts the list of Vector3d to a 2D numpy array """
         return np.array(list(map(lambda x: np.array(x), self.rs.nodes)))

--- a/src/functional/plant_conductivities.py
+++ b/src/functional/plant_conductivities.py
@@ -1,0 +1,138 @@
+import numpy as np
+from scipy import interpolate
+
+"""
+Helper to define age depent tabular values for root conductivities for XylemFluxPython (values are hard coded)
+
+TODO this should be improved !
+
+usage:  after calling:
+init_conductivities(r :XylemFluxPython, age_dependent :bool)
+
+use:
+r.kr_f(age, type)
+r.kx_f(age, type) 
+
+"""
+
+
+def init_conductivities(r, TairC:float = 20):
+    #mg/cm3
+    hPa2cm = 1.0197
+    dEauPure = (999.83952 + TairC * (16.952577 + TairC * 
+        (- 0.0079905127 + TairC * (- 0.000046241757 + TairC * 
+        (0.00000010584601 + TairC * (- 0.00000000028103006)))))) /  (1 + 0.016887236 * TairC)
+    siPhi = (30 - TairC) / (91 + TairC)
+    siEnne=0
+    mu =  pow(10, (- 0.114 + (siPhi * (1.1 + 43.1 * pow(siEnne, 1.25) )))) 
+    mu = mu /(24*60*60)/100/1000; #//mPa s to hPa d, 1.11837e-10 hPa d for pure water at 293.15K
+    mu = mu * hPa2cm #hPa d to cmh2o d 
+
+    #number of vascular bundles
+    VascBundle_leaf = 32
+    VascBundle_stem = 52
+    VascBundle_root = 1 #valid for all root type
+            
+    #radius of xylem type^4 * number per bundle
+    rad_x_l_1   = (0.0015 **4) * 2; rad_x_l_2   = (0.0005 **4) * 2   
+    rad_x_s_1   = (0.0017 **4) * 3; rad_x_s_2   = (0.0008 **4) * 1     
+    rad_x_r0_1  = (0.0015 **4) * 4    
+    rad_x_r12_1 = (0.00041**4) * 4; rad_x_r12_2 = (0.00087**4) * 1
+    rad_x_r3_1  = (0.00068**4) * 1      
+
+    # axial conductivity [cm^3/day]  
+    betaXylX = 1#0.1      
+    kz_l  = VascBundle_leaf *(rad_x_l_1 + rad_x_l_2)    *np.pi /(mu * 8)  * betaXylX
+    kz_s  = VascBundle_stem *(rad_x_s_1 + rad_x_s_2)    *np.pi /(mu * 8) * betaXylX 
+    kz_r0 = VascBundle_root * rad_x_r0_1                *np.pi /(mu * 8) * betaXylX  
+    kz_r1 = VascBundle_root *(rad_x_r12_1 + rad_x_r12_2)*np.pi /(mu * 8)  * betaXylX
+    kz_r2 = VascBundle_root *(rad_x_r12_1 + rad_x_r12_2)*np.pi /(mu * 8)  * betaXylX 
+    kz_r3 = VascBundle_root * rad_x_r3_1                *np.pi /(mu * 8) * betaXylX
+
+    #radial conductivity [1/day],0.00014 #
+    betaXyl = 1#0.1#0.1
+    kr_l  = 3.83e-5 * hPa2cm * betaXyl# init: 3.83e-4 cm/d/hPa
+    kr_s  = 0.#1.e-20  * hPa2cm # set to almost 0
+    kr_r0 =6.37e-5 * hPa2cm * betaXyl
+    kr_r1 =7.9e-5  * hPa2cm * betaXyl
+    kr_r2 =7.9e-5  * hPa2cm * betaXyl
+    kr_r3 =6.8e-5  * hPa2cm * betaXyl
+    ratio_decrease = 1.5/100
+    
+    r.setKrTables([[[kr_r0,kr_r0,kr_r0*ratio_decrease,kr_r0*ratio_decrease],
+                    [kr_r1,kr_r1,kr_r1*ratio_decrease,kr_r1*ratio_decrease],
+                    [kr_r2,kr_r2,kr_r2*ratio_decrease,kr_r2*ratio_decrease],
+                    [kr_r0,kr_r0,kr_r0*ratio_decrease,kr_r0*ratio_decrease]],
+                    [[kr_s],[kr_s] ],[[kr_l]]],
+            [[[0,0.8,1,10000],[0,0.8,1,10000],[0,0.8,1,10000],[0,0.8,1,10000]],
+            [[0],[0]],[[0]]],verbose = True, ageBased = False) 
+            
+    r.setKx([[kz_r0,kz_r1,kz_r2,kz_r0],[kz_s,kz_s ],[kz_l]])
+    
+    Rgaz=8.314 #J K-1 mol-1 = cm^3*MPa/K/mol
+    rho_h2o = dEauPure/1000#g/cm3
+    Mh2o = 18.05 #g/mol
+    MPa2hPa = 10000
+    hPa2cm = 1/0.9806806
+    #log(-) * (cm^3*MPa/K/mol) * (K) *(g/cm3)/ (g/mol) * (hPa/MPa) * (cm/hPa) =  cm                      
+    #p_a = np.log(RH) * Rgaz * rho_h2o * (TairC + 273.15)/Mh2o * MPa2hPa * hPa2cm
+    #done withint solve photosynthesis
+    #r.psi_air = p_a #*MPa2hPa #used only with xylem
+    return r
+    
+def init_conductivities_(r, TairC:float = 20):
+    #mg/cm3
+    hPa2cm = 1.0197
+    dEauPure = (999.83952 + TairC * (16.952577 + TairC * 
+        (- 0.0079905127 + TairC * (- 0.000046241757 + TairC * 
+        (0.00000010584601 + TairC * (- 0.00000000028103006)))))) /  (1 + 0.016887236 * TairC)
+    siPhi = (30 - TairC) / (91 + TairC)
+    siEnne=0
+    mu =  pow(10, (- 0.114 + (siPhi * (1.1 + 43.1 * pow(siEnne, 1.25) )))) 
+    mu = mu /(24*60*60)/100/1000; #//mPa s to hPa d, 1.11837e-10 hPa d for pure water at 293.15K
+    mu = mu * hPa2cm #hPa d to cmh2o d 
+
+    #number of vascular bundles
+    VascBundle_leaf = 32
+    VascBundle_stem = 52
+    VascBundle_root = 1 #valid for all root type
+            
+    #radius of xylem type^4 * number per bundle
+    rad_x_l_1   = (0.0015 **4) * 2; rad_x_l_2   = (0.0005 **4) * 2   
+    rad_x_s_1   = (0.0017 **4) * 3; rad_x_s_2   = (0.0008 **4) * 1     
+    rad_x_r0_1  = (0.0015 **4) * 4    
+    rad_x_r12_1 = (0.00041**4) * 4; rad_x_r12_2 = (0.00087**4) * 1
+    rad_x_r3_1  = (0.00068**4) * 1      
+
+    # axial conductivity [cm^3/day]  
+    betaXylX = 1#0.1      
+    kz_l  = VascBundle_leaf *(rad_x_l_1 + rad_x_l_2)    *np.pi /(mu * 8)  * betaXylX
+    kz_s  = VascBundle_stem *(rad_x_s_1 + rad_x_s_2)    *np.pi /(mu * 8) * betaXylX 
+    kz_r0 = VascBundle_root * rad_x_r0_1                *np.pi /(mu * 8) * betaXylX  
+    kz_r1 = VascBundle_root *(rad_x_r12_1 + rad_x_r12_2)*np.pi /(mu * 8)  * betaXylX
+    kz_r2 = VascBundle_root *(rad_x_r12_1 + rad_x_r12_2)*np.pi /(mu * 8)  * betaXylX 
+    kz_r3 = VascBundle_root * rad_x_r3_1                *np.pi /(mu * 8) * betaXylX
+
+    #radial conductivity [1/day],0.00014 #
+    betaXyl = 1#0.1#0.1
+    kr_l  = 3.83e-5 * hPa2cm * betaXyl# init: 3.83e-4 cm/d/hPa
+    kr_s  = 0.#1.e-20  * hPa2cm # set to almost 0
+    kr_r0 =6.37e-5 * hPa2cm * betaXyl
+    kr_r1 =7.9e-5  * hPa2cm * betaXyl
+    kr_r2 =7.9e-5  * hPa2cm * betaXyl
+    kr_r3 =6.8e-5  * hPa2cm * betaXyl
+    l_kr = 1000# 0.8 #cm
+    r.setKr([[kr_r0,kr_r1,kr_r2,kr_r0],[kr_s,kr_s ],[kr_l]], kr_length_=l_kr) 
+    r.setKx([[kz_r0,kz_r1,kz_r2,kz_r0],[kz_s,kz_s ],[kz_l]])
+    
+    
+    Rgaz=8.314 #J K-1 mol-1 = cm^3*MPa/K/mol
+    rho_h2o = dEauPure/1000#g/cm3
+    Mh2o = 18.05 #g/mol
+    MPa2hPa = 10000
+    hPa2cm = 1/0.9806806
+    #log(-) * (cm^3*MPa/K/mol) * (K) *(g/cm3)/ (g/mol) * (hPa/MPa) * (cm/hPa) =  cm                      
+    #p_a = np.log(RH) * Rgaz * rho_h2o * (TairC + 273.15)/Mh2o * MPa2hPa * hPa2cm
+    #done withint solve photosynthesis
+    #r.psi_air = p_a #*MPa2hPa #used only with xylem
+    return r

--- a/src/functional/van_genuchten.py
+++ b/src/functional/van_genuchten.py
@@ -41,6 +41,16 @@ class Parameters:
 
 def pressure_head(theta, sp):
     """ returns pressure head at a given volumetric water content according to the van genuchten model """
+    try:
+        if isinstance(theta, (type(list()), type(np.array([])))):
+            assert ( theta > sp.theta_R).all()
+            assert (theta <= sp.theta_S).all()
+        else:
+            assert theta > sp.theta_R
+            assert theta <= sp.theta_S
+    except:
+        print('theta <= sp.theta_R or theta > sp.theta_S',theta, sp.theta_R, sp.theta_S)
+        raise Exception
     theta = np.minimum(theta, sp.theta_S)  # saturated water conent is the maximum
     return -pow(pow((sp.theta_S - sp.theta_R) / (theta - sp.theta_R), (1. / sp.m)) - 1., 1. / sp.n) / sp.alpha
 
@@ -64,6 +74,17 @@ def water_diffusivity(TH, theta_i, theta_sur, sp):
 
 def water_content(h, sp):
     """ returns the volumetric water content [1] at a given matric potential [cm] according to the VanGenuchten model (Eqn 21) """
+    try:
+        
+        if isinstance(h, (type(list()), type(np.array([])))):
+            assert (h <= 0).all()
+            assert (h > -np.Inf).all()
+        else:
+            assert h <= 0
+            assert h > -np.Inf
+    except:
+        print('water_content, sp out of range',h)
+        raise Exception
     return sp.theta_R + (sp.theta_S - sp.theta_R) / pow(1. + pow(sp.alpha * abs(h), sp.n), sp.m)
 
 

--- a/src/structural/MappedOrganism.h
+++ b/src/structural/MappedOrganism.h
@@ -36,7 +36,7 @@ public:
 
     void setSoilGrid(const std::function<int(double,double,double)>& s); ///< sets the soil, resets the mappers, and maps all segments
     void setSoilGrid(const std::function<int(double,double,double)>& s, Vector3d min, Vector3d max, Vector3d res, bool cut = true); ///< sets the soil, resets the mappers, cuts and maps all segments
-    void setRectangularGrid(Vector3d min, Vector3d max, Vector3d res, bool cut = true); ///< sets an underlying rectangular grid, and cuts all segments accordingly
+    void setRectangularGrid(Vector3d min, Vector3d max, Vector3d res, bool cut = true, bool noChanges = false); ///< sets an underlying rectangular grid, and cuts all segments accordingly
 
     void mapSegments(const std::vector<Vector2i>& segs);
     void cutSegments(); // cut and add segments
@@ -67,6 +67,7 @@ public:
     Vector3d maxBound;
     Vector3d resolution; // cells
     bool cutAtGrid = false;
+	bool constantLoc = false;// the roots remain in the soil voxel they appear in
 
 	virtual double getPerimeter(int si_, double l_){return 2 * M_PI * radii[si_];} ///< Perimeter of the segment [cm] overloaded by @see MappedPlant::getPerimeter
 	virtual int getSegment2leafId(int si_);
@@ -77,6 +78,7 @@ public:
 	//% of segment length in the root exchange zone, see MappedPlant::simulate.
 	//only needed if carbon- and water-limited growth (i.e., for plants with phloem module)
 	std::vector<double> exchangeZoneCoefs;
+	std::vector<double> distanceTip;// save the distance between root segment and root tip (for location-dependent kr)
 	std::vector<double> leafBladeSurface; //leaf blade area per segment to define water radial flux. assume no radial flux in petiole
 	std::vector<double> segVol; //segment volume <= needed for MappedPlant as leaf does not have cylinder shape necessarally only do segLeaf to have shorter vector?
 	std::vector<double> bladeLength;//blade length <= needed for MappedPlant as leaf does not have cylinder shape necessarally only do segLeaf to have shorter vector?

--- a/src/structural/tropism.cpp
+++ b/src/structural/tropism.cpp
@@ -128,7 +128,7 @@ Vector2d Tropism::getHeading(const Vector3d& pos, const Matrix3d& old, double dx
             }
 
             if (i>alphaN) {
-                std::cout << "Could not respect geometry boundaries \n";
+                //std::cout << "Could not respect geometry boundaries \n";
                 a = bestA;
                 b = bestB;
                 break;


### PR DESCRIPTION
update CPlantBox to make it work with TriaRhizo (==> add soil exudation).
The 'core files' changed are:

- src/functional/XylemFlux.h: added a function to make kr depend on the distance from the root tip. When the carbon-limited growth is implemented, we cannot use the age-dependent kr variation
- src/functional/XylemFlux.cpp:  
        [a] replaced kr_f with kr_f_wrapped. Now if a leaf segment is belowground (resp. leaf segment below ground), we have kr = 0 instead of a computational error
[b] sumSegFluxes() and splitSoilFluxes(() adapted for full plants 

- src/structural/MappedOrganism.cpp:
[a] setRectangularGrid(), MappedPlant::simulate(): if we have a growing root system and a dumux-cpb coupling, we can set noChanges==True, so that segments remain in the voxel there were first aloccated to.
[b] MappedPlant::calcExchangeZoneCoefs(): compute the distance from the tip of each root segment, used afterwards by the xylemflux class when computing kr