### PR TITLE
fix is plantBox test

### DIFF
--- a/src/structural/MappedOrganism.cpp
+++ b/src/structural/MappedOrganism.cpp
@@ -591,9 +591,9 @@ std::vector<double> MappedSegments::getEffectiveRadii() {
  */
 void MappedPlant::initialize_(bool verbose, bool lengthBased) {
 
-    reset(); // just in case (Plant::reset()) (carefull, MappedPlant cannot reset, yet)
+    reset(); // just in case (Plant::reset()) (careful, MappedPlant cannot reset, yet)
 	auto stemP = getOrganRandomParameter(Organism::ot_stem);
-	bool plantBox = stemP.size()>0;
+	bool plantBox = stemP.size()>1; // prototype + a real parameter definition
 	if (plantBox) {
 		disableExtraNode(); // no meed for additional node to create the artificial stem 
 	}

--- a/src/structural/Plant.cpp
+++ b/src/structural/Plant.cpp
@@ -58,9 +58,9 @@ void Plant::initializeReader()
     auto strp = std::make_shared<StemRandomParameter>(shared_from_this());
     strp->subType = 0;
     setOrganRandomParameter(strp);
-    auto strp1 = std::make_shared<StemRandomParameter>(shared_from_this()); // Dummy stem, in case there is no stem defined
-    strp1->subType = 1;
-    setOrganRandomParameter(strp1);
+    // auto strp1 = std::make_shared<StemRandomParameter>(shared_from_this()); // Dummy stem, in case there is no stem defined
+    // strp1->subType = 1;
+    // setOrganRandomParameter(strp1);
     auto lrp = std::make_shared<LeafRandomParameter>(shared_from_this());
     lrp->subType = 0;
     setOrganRandomParameter(lrp);

--- a/src/structural/Seed.cpp
+++ b/src/structural/Seed.cpp
@@ -51,7 +51,7 @@ void Seed::initialize(bool verbose)
 {
 	auto p = plant.lock();
 	auto stemP = p->getOrganRandomParameter(Organism::ot_stem);
-	bool plantBox = stemP.size()>0;
+	bool plantBox = stemP.size()>1; // prototype + a real parameter definition
 	if (verbose) {
 		if (plantBox) {
 			std::cout << "Seed::initialize: Plant \n";


### PR DESCRIPTION
a very small update but I is affects core CPB files.
The test to see if we have a plant or a rootsystem is now StemRandomParameter.size() > 1
We always have the random parameter prototype (subtype 0).
@Plant::initializeReader() : we stop definind a stem of subtype 12 per default. 