### PR TITLE
Install module into Python environment per default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.5)
-project (CPlantBox)
+project (CPlantBox LANGUAGES CXX)
 
 # set compiler options
 set(RELEASE_WARNING_OPTS "-Wall -Wunused -Wmissing-include-dirs -Wcast-align -Wno-sign-compare  ")
@@ -7,13 +7,11 @@ set(DEBUG_WARNING_OPTS "-Wall -Wunused -Wmissing-include-dirs -Wcast-align -Wno-
 set(RELEASE_OPTS "-std=c++17 -fno-strict-aliasing -fstrict-overflow -fno-finite-math-only -O3 -march=native -funroll-loops -g0 ")
 set(CMAKE_CXX_FLAGS_RELEASE "${RELEASE_WARNING_OPTS} ${RELEASE_OPTS}")
 set(CMAKE_CXX_FLAGS_DEBUG "-std=c++17 -O0 -ggdb -Wall")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # set default build type to release Release, Debug, RelWithDebInfo 
 set(CMAKE_BUILD_TYPE RelWithDebInfo)
-
-# add source directory to the include path
-include_directories(${PROJECT_SOURCE_DIR}/src/structural)
-include_directories(${PROJECT_SOURCE_DIR}/src/functional)
 
 # add subdirectories
 add_subdirectory(src)

--- a/installCPlantBox.py
+++ b/installCPlantBox.py
@@ -130,7 +130,7 @@ os.chdir("CPlantBox")
 
 subprocess.run(['git', 'submodule', 'update', '--recursive', '--init'])
 subprocess.run(['cmake', '.'])
-subprocess.run(['make'])
+subprocess.run(['make install'])
 os.chdir("..")
 
 show_message("(2/2) Step completed. Succesfully configured and built CPlantBox.")
@@ -138,5 +138,4 @@ show_message("(2/2) Step completed. Succesfully configured and built CPlantBox."
 show_message("to test installation, run \n cd CPlantBox/tutorial/examples/ \n python3 example1a_small.py")
 
 show_message("CPlantBox is currently at stable branch, use \n $git switch master \n to obtain the latest version, use cmake . & make to recompile")
-
 

--- a/installDumuxRosi_Ubuntu.py
+++ b/installDumuxRosi_Ubuntu.py
@@ -108,7 +108,7 @@ for mymodule in modules:
         raise Exception
 
 # pip3 install --upgrade pip setuptools wheel # necessary?
-subprocess.run(["python3", "-m", "pip","install", "--no-cache-dir", "mpi4py", "--verbose"])  # mpi4py can take a lot of time to install
+subprocess.run(["python3", "-m", "pip", "install", "--no-cache-dir", "mpi4py", "--verbose"])  # mpi4py can take a lot of time to install
 
 show_message("(1/3) Step completed. All prerequistes found.")
 
@@ -150,7 +150,7 @@ os.chdir("CPlantBox")
 
 subprocess.run(['git', 'submodule', 'update', '--recursive', '--init'])
 subprocess.run(['cmake', '.'])
-subprocess.run(['make'])
+subprocess.run(['make install'])
 os.chdir("..")
 
 # run dunecontrol

--- a/modelparameter/functional/soil_hydraulics/readme
+++ b/modelparameter/functional/soil_hydraulics/readme
@@ -1,2 +1,5 @@
 Soil hydraulic parameters 
 
+e.g.
+* VG curves 
+* Look up tables for potentials at root soil interface

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(CPlantBox LANGUAGES CXX)
 
+
+message(STATUS "Project source dir: ${PROJECT_SOURCE_DIR}")
 message(STATUS "Current source dir: ${CMAKE_CURRENT_SOURCE_DIR}")
 message(STATUS "Project binary dir: ${PROJECT_BINARY_DIR}")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -162,5 +162,10 @@ set_target_properties(plantbox PROPERTIES
 )
 
 # Install plantbox module into Python site-packages
-install(TARGETS CPlantBox LIBRARY DESTINATION "${Python3_SITEARCH}")
+install(TARGETS CPlantBox LIBRARY DESTINATION "${Python3_SITEARCH}") 
 install(TARGETS plantbox LIBRARY DESTINATION "${Python3_SITEARCH}")
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/visualisation DESTINATION ${Python3_SITEARCH})
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/rsml DESTINATION ${Python3_SITEARCH})
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/structural DESTINATION ${Python3_SITEARCH})
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/functional DESTINATION ${Python3_SITEARCH})
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,107 +1,94 @@
-#
-# 1. Make CPlantBox library
-#
+cmake_minimum_required(VERSION 3.16)
+project(CPlantBox LANGUAGES CXX)
 
-include_directories(structural)
-include_directories(functional)
-include_directories(visualisation)
+message(STATUS "Current source dir: ${CMAKE_CURRENT_SOURCE_DIR}")
+message(STATUS "Project binary dir: ${PROJECT_BINARY_DIR}")
 
-include_directories(external/tinyxml2)
-include_directories(external/eigen) # fetching as git submodule @tag 3.3.7
+# 1. Dependencies
+find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+add_subdirectory(external/pybind11)
 
-include_directories(external/) # for PiafMunch
-include_directories(${PROJECT_SOURCE_DIR}/src/external/suitsparse/include/) # for PiafMunch
-include_directories(${PROJECT_SOURCE_DIR}/src/external/sundials/include/) # for PiafMunch
-
-
+# 2. Main C++ library
 add_library(CPlantBox SHARED
-            structural/organparameter.cpp
-            structural/rootparameter.cpp
-			structural/seedparameter.cpp
-			structural/leafparameter.cpp
-			structural/stemparameter.cpp
-            structural/Organ.cpp
-            structural/Root.cpp
-            structural/RootDelay.cpp            
-            structural/Seed.cpp
-			structural/Stem.cpp
-			structural/Leaf.cpp
-			structural/Plant.cpp
-            structural/Organism.cpp
-            structural/Plant.cpp            
-            structural/RootSystem.cpp
-            structural/MappedOrganism.cpp
-     		structural/sdf.cpp
-            structural/SegmentAnalyser.cpp            
-            structural/tropism.cpp            
-			
-            functional/XylemFlux.cpp
-			functional/Photosynthesis.cpp
-			functional/Perirhizal.cpp
-			functional/PlantHydraulicParameters.cpp
-			functional/PlantHydraulicModel.cpp			
-
-			visualisation/Quaternion.h
-			visualisation/CatmullRomSpline.h
-			visualisation/PlantVisualiser.h
-			visualisation/PlantVisualiser.cpp
-            
-			external/tinyxml2/tinyxml2.cpp		
-			external/aabbcc/AABB.cc
-            external/gauss_legendre/gauss_legendre.cpp
-			external/PiafMunch/runPM.cpp     
-			external/PiafMunch/PiafMunch2.cpp     
-			external/PiafMunch/index_vector.cpp
-			external/PiafMunch/initialize.cpp
-			external/PiafMunch/odepack.cpp
-			external/PiafMunch/PM_KLU.cpp
-			external/PiafMunch/PM_matrix.cpp
-			external/PiafMunch/PM_vector.cpp
-			external/PiafMunch/solve.cpp
-			external/PiafMunch/sparse_matrix.cpp            
+    structural/organparameter.cpp
+    structural/rootparameter.cpp
+    structural/seedparameter.cpp
+    structural/leafparameter.cpp
+    structural/stemparameter.cpp
+    structural/Organ.cpp
+    structural/Root.cpp
+    structural/RootDelay.cpp
+    structural/Seed.cpp
+    structural/Stem.cpp
+    structural/Leaf.cpp
+    structural/Plant.cpp
+    structural/Organism.cpp
+    structural/RootSystem.cpp
+    structural/MappedOrganism.cpp
+    structural/sdf.cpp
+    structural/SegmentAnalyser.cpp
+    structural/tropism.cpp
+    functional/XylemFlux.cpp
+    functional/Photosynthesis.cpp
+    functional/Perirhizal.cpp
+    functional/PlantHydraulicParameters.cpp
+    functional/PlantHydraulicModel.cpp
+    visualisation/PlantVisualiser.cpp
+    external/tinyxml2/tinyxml2.cpp
+    external/aabbcc/AABB.cc
+    external/gauss_legendre/gauss_legendre.cpp
+    external/PiafMunch/runPM.cpp
+    external/PiafMunch/PiafMunch2.cpp
+    external/PiafMunch/index_vector.cpp
+    external/PiafMunch/initialize.cpp
+    external/PiafMunch/odepack.cpp
+    external/PiafMunch/PM_KLU.cpp
+    external/PiafMunch/PM_matrix.cpp
+    external/PiafMunch/PM_vector.cpp
+    external/PiafMunch/solve.cpp
+    external/PiafMunch/sparse_matrix.cpp
 )
 
-
 add_library(libklu SHARED IMPORTED)
-set_property(TARGET libklu PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/suitsparse/lib/libklu.a)
+set_property(TARGET libklu PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/suitsparse/lib/libklu.a)
 add_library(libamd SHARED IMPORTED)
-set_property(TARGET libamd PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/suitsparse/lib/libamd.a)
+set_property(TARGET libamd PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/suitsparse/lib/libamd.a)
 add_library(libbtf SHARED IMPORTED)
-set_property(TARGET libbtf PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/suitsparse/lib/libbtf.a)
+set_property(TARGET libbtf PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/suitsparse/lib/libbtf.a)
 add_library(libcolamd SHARED IMPORTED)
-set_property(TARGET libcolamd PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/suitsparse/lib/libcolamd.a)
+set_property(TARGET libcolamd PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/suitsparse/lib/libcolamd.a)
 add_library(suitesparseconfig SHARED IMPORTED)
-set_property(TARGET suitesparseconfig PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/suitsparse/lib/libsuitesparseconfig.a)
+set_property(TARGET suitesparseconfig PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/suitsparse/lib/libsuitesparseconfig.a)
 add_library(arkode SHARED IMPORTED)
-set_target_properties(arkode PROPERTIES IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_arkode.a)
+set_target_properties(arkode PROPERTIES IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_arkode.a)
 add_library(sundials_cvode SHARED IMPORTED)
-set_property(TARGET sundials_cvode PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_cvode.a)
+set_property(TARGET sundials_cvode PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_cvode.a)
 add_library(sundials_nvecserial SHARED IMPORTED)
-set_property(TARGET sundials_nvecserial PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_nvecserial.a)
+set_property(TARGET sundials_nvecserial PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_nvecserial.a)
 add_library(sundials_sunlinsolband SHARED IMPORTED)
-set_property(TARGET sundials_sunlinsolband PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunlinsolband.a)
+set_property(TARGET sundials_sunlinsolband PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunlinsolband.a)
 add_library(sundials_sunlinsoldense SHARED IMPORTED)
-set_property(TARGET sundials_sunlinsoldense PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunlinsoldense.a)
+set_property(TARGET sundials_sunlinsoldense PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunlinsoldense.a)
 add_library(sundials_sunlinsolklu SHARED IMPORTED)
-set_property(TARGET sundials_sunlinsolklu PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunlinsolklu.a)
+set_property(TARGET sundials_sunlinsolklu PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunlinsolklu.a)
 add_library(sundials_sunlinsolpcg SHARED IMPORTED)
-set_property(TARGET sundials_sunlinsolpcg PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunlinsolpcg.a)
+set_property(TARGET sundials_sunlinsolpcg PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunlinsolpcg.a)
 add_library(sundials_sunlinsolspbcgs SHARED IMPORTED)
-set_property(TARGET sundials_sunlinsolspbcgs PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunlinsolspbcgs.a)
+set_property(TARGET sundials_sunlinsolspbcgs PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunlinsolspbcgs.a)
 add_library(sundials_sunlinsolspfgmr SHARED IMPORTED)
-set_property(TARGET sundials_sunlinsolspfgmr PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunlinsolspfgmr.a)
+set_property(TARGET sundials_sunlinsolspfgmr PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunlinsolspfgmr.a)
 add_library(sundials_sunlinsolspgmr SHARED IMPORTED)
-set_property(TARGET sundials_sunlinsolspgmr PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunlinsolspgmr.a)
+set_property(TARGET sundials_sunlinsolspgmr PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunlinsolspgmr.a)
 add_library(sundials_sunlinsolsptfqmr SHARED IMPORTED)
-set_property(TARGET sundials_sunlinsolsptfqmr PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunlinsolsptfqmr.a)
+set_property(TARGET sundials_sunlinsolsptfqmr PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunlinsolsptfqmr.a)
 add_library(sundials_sunmatrixband SHARED IMPORTED)
-set_property(TARGET sundials_sunmatrixband PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunmatrixband.a)
+set_property(TARGET sundials_sunmatrixband PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunmatrixband.a)
 add_library(sundials_sunmatrixdense SHARED IMPORTED)
-set_property(TARGET sundials_sunmatrixdense PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunmatrixdense.a)
+set_property(TARGET sundials_sunmatrixdense PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunmatrixdense.a)
 add_library(sundials_sunmatrixsparse SHARED IMPORTED)
-set_target_properties(sundials_sunmatrixsparse PROPERTIES IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunmatrixsparse.a)
+set_target_properties(sundials_sunmatrixsparse PROPERTIES IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunmatrixsparse.a)
 add_library(sundials_sunnonlinsolnewton SHARED IMPORTED)
-set_target_properties(sundials_sunnonlinsolnewton PROPERTIES IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunnonlinsolnewton.a)
+set_target_properties(sundials_sunnonlinsolnewton PROPERTIES IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunnonlinsolnewton.a)
 target_link_libraries(CPlantBox 
 						sundials_sunnonlinsolnewton 
 						sundials_sunmatrixsparse 
@@ -129,29 +116,29 @@ set_target_properties(CPlantBox PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BI
 target_include_directories(
                         CPlantBox
                         PUBLIC
-                        ${PROJECT_BINARY_DIR}/src/external/sundials/include
-                        ${PROJECT_BINARY_DIR}/src/external/suitsparse/include
+                        ${PROJECT_BINARY_DIR}/external/sundials/include
+                        ${PROJECT_BINARY_DIR}/external/suitsparse/include
 )
-#
-# 2. Make CPlantBox Pyhthon binding
-#
 
-# find_package(pybind11 REQUIRED) 
-#set(PYBIND11_PYTHON_VERSION 3.7)
-#find_package( PythonInterp 3.7 REQUIRED )
-#find_package( PythonLibs 3.7 REQUIRED )
-add_subdirectory(external/pybind11)
-
-pybind11_add_module(plantbox SHARED 
-			PyPlantBox.cpp   								
-			)
-target_link_libraries(plantbox PUBLIC 
-			CPlantBox)
-			
-set_target_properties(plantbox PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/)
+# Set library output directory
+set_target_properties(CPlantBox PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+    BUILD_WITH_INSTALL_RPATH TRUE
+    INSTALL_RPATH "$ORIGIN"
+)
 
 
+# -----------------------------
+# 6. Python binding
+# -----------------------------
 
+pybind11_add_module(plantbox PyPlantBox.cpp)
+target_link_libraries(plantbox PRIVATE CPlantBox Python3::Module)
 
+set_target_properties(plantbox PROPERTIES
+    INSTALL_RPATH "$ORIGIN"
+)
 
-
+# Install plantbox module into Python site-packages
+install(TARGETS CPlantBox LIBRARY DESTINATION "${Python3_SITEARCH}")
+install(TARGETS plantbox LIBRARY DESTINATION "${Python3_SITEARCH}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,96 +1,116 @@
-cmake_minimum_required(VERSION 3.16)
-project(CPlantBox LANGUAGES CXX)
-
-
-message(STATUS "Project source dir: ${PROJECT_SOURCE_DIR}")
+message(STATUS "Project dir: ${PROJECT_SOURCE_DIR}")
 message(STATUS "Current source dir: ${CMAKE_CURRENT_SOURCE_DIR}")
 message(STATUS "Project binary dir: ${PROJECT_BINARY_DIR}")
 
-# 1. Dependencies
+
+# -----------------------------
+# 1. Dependencies & Includes
+# -----------------------------
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 add_subdirectory(external/pybind11)
 
-# 2. Main C++ library
+include_directories(structural)
+include_directories(functional)
+include_directories(visualisation)
+
+include_directories(external/tinyxml2)
+include_directories(external/eigen) # fetching as git submodule @tag 3.3.7
+
+include_directories(external/) # for PiafMunch
+include_directories(${PROJECT_SOURCE_DIR}/src/external/suitsparse/include/) # for PiafMunch
+include_directories(${PROJECT_SOURCE_DIR}/src/external/sundials/include/) # for PiafMunch
+
+# -----------------------------
+# Shared Library
+# -----------------------------
 add_library(CPlantBox SHARED
-    structural/organparameter.cpp
-    structural/rootparameter.cpp
-    structural/seedparameter.cpp
-    structural/leafparameter.cpp
-    structural/stemparameter.cpp
-    structural/Organ.cpp
-    structural/Root.cpp
-    structural/RootDelay.cpp
-    structural/Seed.cpp
-    structural/Stem.cpp
-    structural/Leaf.cpp
-    structural/Plant.cpp
-    structural/Organism.cpp
-    structural/RootSystem.cpp
-    structural/MappedOrganism.cpp
-    structural/sdf.cpp
-    structural/SegmentAnalyser.cpp
-    structural/tropism.cpp
-    functional/XylemFlux.cpp
-    functional/Photosynthesis.cpp
-    functional/Perirhizal.cpp
-    functional/PlantHydraulicParameters.cpp
-    functional/PlantHydraulicModel.cpp
-    visualisation/PlantVisualiser.cpp
-    external/tinyxml2/tinyxml2.cpp
-    external/aabbcc/AABB.cc
-    external/gauss_legendre/gauss_legendre.cpp
-    external/PiafMunch/runPM.cpp
-    external/PiafMunch/PiafMunch2.cpp
-    external/PiafMunch/index_vector.cpp
-    external/PiafMunch/initialize.cpp
-    external/PiafMunch/odepack.cpp
-    external/PiafMunch/PM_KLU.cpp
-    external/PiafMunch/PM_matrix.cpp
-    external/PiafMunch/PM_vector.cpp
-    external/PiafMunch/solve.cpp
-    external/PiafMunch/sparse_matrix.cpp
+            structural/organparameter.cpp
+            structural/rootparameter.cpp
+			structural/seedparameter.cpp
+			structural/leafparameter.cpp
+			structural/stemparameter.cpp
+            structural/Organ.cpp
+            structural/Root.cpp
+            structural/RootDelay.cpp            
+            structural/Seed.cpp
+			structural/Stem.cpp
+			structural/Leaf.cpp
+			structural/Plant.cpp
+            structural/Organism.cpp
+            structural/Plant.cpp            
+            structural/RootSystem.cpp
+            structural/MappedOrganism.cpp
+     		structural/sdf.cpp
+            structural/SegmentAnalyser.cpp            
+            structural/tropism.cpp            
+			
+            functional/XylemFlux.cpp
+			functional/Photosynthesis.cpp
+			functional/Perirhizal.cpp
+			functional/PlantHydraulicParameters.cpp
+			functional/PlantHydraulicModel.cpp			
+
+			visualisation/Quaternion.h
+			visualisation/CatmullRomSpline.h
+			visualisation/PlantVisualiser.h
+			visualisation/PlantVisualiser.cpp
+            
+			external/tinyxml2/tinyxml2.cpp		
+			external/aabbcc/AABB.cc
+            external/gauss_legendre/gauss_legendre.cpp
+			external/PiafMunch/runPM.cpp     
+			external/PiafMunch/PiafMunch2.cpp     
+			external/PiafMunch/index_vector.cpp
+			external/PiafMunch/initialize.cpp
+			external/PiafMunch/odepack.cpp
+			external/PiafMunch/PM_KLU.cpp
+			external/PiafMunch/PM_matrix.cpp
+			external/PiafMunch/PM_vector.cpp
+			external/PiafMunch/solve.cpp
+			external/PiafMunch/sparse_matrix.cpp            
 )
 
+
 add_library(libklu SHARED IMPORTED)
-set_property(TARGET libklu PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/suitsparse/lib/libklu.a)
+set_property(TARGET libklu PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/suitsparse/lib/libklu.a)
 add_library(libamd SHARED IMPORTED)
-set_property(TARGET libamd PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/suitsparse/lib/libamd.a)
+set_property(TARGET libamd PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/suitsparse/lib/libamd.a)
 add_library(libbtf SHARED IMPORTED)
-set_property(TARGET libbtf PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/suitsparse/lib/libbtf.a)
+set_property(TARGET libbtf PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/suitsparse/lib/libbtf.a)
 add_library(libcolamd SHARED IMPORTED)
-set_property(TARGET libcolamd PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/suitsparse/lib/libcolamd.a)
+set_property(TARGET libcolamd PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/suitsparse/lib/libcolamd.a)
 add_library(suitesparseconfig SHARED IMPORTED)
-set_property(TARGET suitesparseconfig PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/suitsparse/lib/libsuitesparseconfig.a)
+set_property(TARGET suitesparseconfig PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/suitsparse/lib/libsuitesparseconfig.a)
 add_library(arkode SHARED IMPORTED)
-set_target_properties(arkode PROPERTIES IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_arkode.a)
+set_target_properties(arkode PROPERTIES IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_arkode.a)
 add_library(sundials_cvode SHARED IMPORTED)
-set_property(TARGET sundials_cvode PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_cvode.a)
+set_property(TARGET sundials_cvode PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_cvode.a)
 add_library(sundials_nvecserial SHARED IMPORTED)
-set_property(TARGET sundials_nvecserial PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_nvecserial.a)
+set_property(TARGET sundials_nvecserial PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_nvecserial.a)
 add_library(sundials_sunlinsolband SHARED IMPORTED)
-set_property(TARGET sundials_sunlinsolband PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunlinsolband.a)
+set_property(TARGET sundials_sunlinsolband PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunlinsolband.a)
 add_library(sundials_sunlinsoldense SHARED IMPORTED)
-set_property(TARGET sundials_sunlinsoldense PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunlinsoldense.a)
+set_property(TARGET sundials_sunlinsoldense PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunlinsoldense.a)
 add_library(sundials_sunlinsolklu SHARED IMPORTED)
-set_property(TARGET sundials_sunlinsolklu PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunlinsolklu.a)
+set_property(TARGET sundials_sunlinsolklu PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunlinsolklu.a)
 add_library(sundials_sunlinsolpcg SHARED IMPORTED)
-set_property(TARGET sundials_sunlinsolpcg PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunlinsolpcg.a)
+set_property(TARGET sundials_sunlinsolpcg PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunlinsolpcg.a)
 add_library(sundials_sunlinsolspbcgs SHARED IMPORTED)
-set_property(TARGET sundials_sunlinsolspbcgs PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunlinsolspbcgs.a)
+set_property(TARGET sundials_sunlinsolspbcgs PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunlinsolspbcgs.a)
 add_library(sundials_sunlinsolspfgmr SHARED IMPORTED)
-set_property(TARGET sundials_sunlinsolspfgmr PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunlinsolspfgmr.a)
+set_property(TARGET sundials_sunlinsolspfgmr PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunlinsolspfgmr.a)
 add_library(sundials_sunlinsolspgmr SHARED IMPORTED)
-set_property(TARGET sundials_sunlinsolspgmr PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunlinsolspgmr.a)
+set_property(TARGET sundials_sunlinsolspgmr PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunlinsolspgmr.a)
 add_library(sundials_sunlinsolsptfqmr SHARED IMPORTED)
-set_property(TARGET sundials_sunlinsolsptfqmr PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunlinsolsptfqmr.a)
+set_property(TARGET sundials_sunlinsolsptfqmr PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunlinsolsptfqmr.a)
 add_library(sundials_sunmatrixband SHARED IMPORTED)
-set_property(TARGET sundials_sunmatrixband PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunmatrixband.a)
+set_property(TARGET sundials_sunmatrixband PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunmatrixband.a)
 add_library(sundials_sunmatrixdense SHARED IMPORTED)
-set_property(TARGET sundials_sunmatrixdense PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunmatrixdense.a)
+set_property(TARGET sundials_sunmatrixdense PROPERTY IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunmatrixdense.a)
 add_library(sundials_sunmatrixsparse SHARED IMPORTED)
-set_target_properties(sundials_sunmatrixsparse PROPERTIES IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunmatrixsparse.a)
+set_target_properties(sundials_sunmatrixsparse PROPERTIES IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunmatrixsparse.a)
 add_library(sundials_sunnonlinsolnewton SHARED IMPORTED)
-set_target_properties(sundials_sunnonlinsolnewton PROPERTIES IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/external/sundials/lib/libsundials_sunnonlinsolnewton.a)
+set_target_properties(sundials_sunnonlinsolnewton PROPERTIES IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/external/sundials/lib/libsundials_sunnonlinsolnewton.a)
 target_link_libraries(CPlantBox 
 						sundials_sunnonlinsolnewton 
 						sundials_sunmatrixsparse 
@@ -115,11 +135,12 @@ target_link_libraries(CPlantBox
 						)
 
 set_target_properties(CPlantBox PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/)
+
 target_include_directories(
                         CPlantBox
                         PUBLIC
-                        ${PROJECT_BINARY_DIR}/external/sundials/include
-                        ${PROJECT_BINARY_DIR}/external/suitsparse/include
+                        ${PROJECT_BINARY_DIR}/src/external/sundials/include
+                        ${PROJECT_BINARY_DIR}/src/external/suitsparse/include
 )
 
 # Set library output directory
@@ -129,9 +150,8 @@ set_target_properties(CPlantBox PROPERTIES
     INSTALL_RPATH "$ORIGIN"
 )
 
-
 # -----------------------------
-# 6. Python binding
+# Python binding
 # -----------------------------
 
 pybind11_add_module(plantbox PyPlantBox.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,8 +164,21 @@ set_target_properties(plantbox PROPERTIES
 # Install plantbox module into Python site-packages
 install(TARGETS CPlantBox LIBRARY DESTINATION "${Python3_SITEARCH}") 
 install(TARGETS plantbox LIBRARY DESTINATION "${Python3_SITEARCH}")
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/visualisation DESTINATION ${Python3_SITEARCH})
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/rsml DESTINATION ${Python3_SITEARCH})
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/structural DESTINATION ${Python3_SITEARCH})
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/functional DESTINATION ${Python3_SITEARCH})
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/visualisation DESTINATION ${Python3_SITEARCH} 
+		FILES_MATCHING
+        PATTERN "*.py"
+        PATTERN "__pycache__" EXCLUDE)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/rsml DESTINATION ${Python3_SITEARCH}
+		FILES_MATCHING
+        PATTERN "*.py"
+        PATTERN "__pycache__" EXCLUDE)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/structural DESTINATION ${Python3_SITEARCH}
+		FILES_MATCHING
+        PATTERN "*.py"
+        PATTERN "__pycache__" EXCLUDE)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/functional DESTINATION ${Python3_SITEARCH}
+		FILES_MATCHING
+        PATTERN "*.py"
+        PATTERN "__pycache__" EXCLUDE)
 

--- a/tutorial/chapter1_introduction/example1_3_helloplant.py
+++ b/tutorial/chapter1_introduction/example1_3_helloplant.py
@@ -1,5 +1,3 @@
-import sys;sys.path.append("../..");sys.path.append("../../src/")  # |\label{l13:path}|
-
 import plantbox as pb  # |\label{l13:cplantbox}|
 import visualisation.vtk_plot as vp  # |\label{l13:vtk_plot}|
 


### PR DESCRIPTION
I modified our cmake and install scripts, so that plantbox is installed into the active python environment (by make install).
Then we do not need to manually add the paths via sys in the Python scripts anymore. 

Unfortunately, the naming visualisation, rsml, funcitonal, etc. is rather generic, and we probably should switch to plantbox.visualisation, plantbox.rsml, plantbox.funcitonal in a second step. 

Please let me know what you think
