### PR TITLE
factory functions introduced to Organism class

### DIFF
--- a/src/structural/Organ.cpp
+++ b/src/structural/Organ.cpp
@@ -846,21 +846,21 @@ void Organ::createLateral(double dt, bool verbose) {
 
                     switch (ot) {
                     case Organism::ot_root: {
-                        auto lateral = std::make_shared<Root>(plant.lock(), st, delay, shared_from_this(), nodes.size() - 1);
+                        auto lateral = plant.lock()->createRoot(st, delay, shared_from_this(), nodes.size() - 1);
                         lateral->has_rel_coord = this->has_rel_coord;
                         children.push_back(lateral);
                         lateral->simulate(growth_dt, verbose);
                         break;
                     }
                     case Organism::ot_stem: {
-                        auto lateral = std::make_shared<Stem>(plant.lock(), st, delay, shared_from_this(), nodes.size() - 1);
+                        auto lateral = plant.lock()->createStem(st, delay, shared_from_this(), nodes.size() - 1);
                         lateral->has_rel_coord = this->has_rel_coord;
                         children.push_back(lateral);
                         lateral->simulate(growth_dt, verbose);
                         break;
                     }
                     case Organism::ot_leaf: {
-                        auto lateral = std::make_shared<Leaf>(plant.lock(), st, delay, shared_from_this(), nodes.size() - 1);
+                        auto lateral = plant.lock()->createLeaf(st, delay, shared_from_this(), nodes.size() - 1);
                         lateral->has_rel_coord = this->has_rel_coord;
                         children.push_back(lateral);
                         lateral->simulate(growth_dt, verbose); // age-ageLN,verbose);

--- a/src/structural/Organism.cpp
+++ b/src/structural/Organism.cpp
@@ -4,6 +4,9 @@
 #include "Organ.h"
 #include "Seed.h"
 #include "organparameter.h"
+#include "Root.h"
+#include "Stem.h"
+#include "Leaf.h"
 
 #include <chrono>
 #include <ctime>
@@ -913,5 +916,49 @@ void Organism::setSeed(unsigned int seed) { this->gen = std::mt19937(seed); }
  * @brief Returns the seed organ.
  */
 std::shared_ptr<Seed> Organism::getSeed() { return std::static_pointer_cast<Seed>(baseOrgans.at(0)); }
+
+/**
+ * @brief Creates a new Seed organ.
+ * @return shared pointer to the newly created Seed
+ */
+std::shared_ptr<Seed> Organism::createSeed() {
+    return std::make_shared<Seed>(shared_from_this()); // default base implementation
+}
+
+/**
+ * @brief Creates a new Root organ.
+ * @param subType sub-type index used to select root random parameters
+ * @param delay emergence delay [days]
+ * @param parent parent organ that bears this root
+ * @param pni parent node index where this root emerges
+ * @return shared pointer to the newly created Root
+ */
+std::shared_ptr<Root> Organism::createRoot(int subType, double delay, std::shared_ptr<Organ> parent, int pni) {
+    return std::make_shared<Root>(shared_from_this(), subType, delay, parent, pni);
+}
+
+/**
+ * @brief Creates a new Stem organ.
+ * @param subType sub-type index used to select stem random parameters
+ * @param delay emergence delay [days]
+ * @param parent parent organ that bears this stem
+ * @param pni parent node index where this stem emerges
+ * @return shared pointer to the newly created Stem
+ */
+std::shared_ptr<Stem> Organism::createStem(int subType, double delay, std::shared_ptr<Organ> parent, int pni) {
+    return std::make_shared<Stem>(shared_from_this(), subType, delay, parent, pni);
+}
+
+/**
+ * @brief Creates a new Leaf organ.
+ * @param subType sub-type index used to select leaf random parameters
+ * @param delay emergence delay [days]
+ * @param parent parent organ that bears this leaf
+ * @param pni parent node index where this leaf emerges
+ * @return shared pointer to the newly created Leaf
+ */
+std::shared_ptr<Leaf> Organism::createLeaf(int subType, double delay, std::shared_ptr<Organ> parent, int pni) {
+    return std::make_shared<Leaf>(shared_from_this(), subType, delay, parent, pni);
+}
 
 } // namespace CPlantBox

--- a/src/structural/Organism.h
+++ b/src/structural/Organism.h
@@ -4,20 +4,26 @@
 
 #include "mymath.h"
 #include "sdf.h"
-#include "tinyxml2.h"
 
 #include <array>
-#include <chrono>
-#include <iostream>
+#include <iosfwd>
 #include <map>
 #include <memory>
 #include <random>
+
+namespace tinyxml2 {
+class XMLDocument;
+class XMLElement;
+} // namespace tinyxml2
 
 namespace CPlantBox {
 
 class Organ;
 class OrganRandomParameter;
 class Seed;
+class Root;
+class Stem;
+class Leaf;
 
 /**
  * @brief Base container for plant organs and global simulation state.
@@ -98,30 +104,19 @@ class Organism : public std::enable_shared_from_this<Organism> {
     /* io */
     virtual std::string toString() const; ///< quick info for debugging
     virtual void initializeReader() {}    ///< initializes parameter reader
-    virtual void readParameters(std::string name, std::string basetag = "plant", bool fromFile = true,
-                                bool verbose = false); ///< reads all organ type parameters from a xml file
-    virtual std::string writeParameters(std::string name, std::string basetag = "plant", bool intoFile = true,
-                                        bool comments = true) const;             ///< write all organ type parameters into a xml file
+    virtual void readParameters(std::string name, std::string basetag = "plant", bool fromFile = true, bool verbose = false); ///< reads all organ type parameters from a xml file
+    virtual std::string writeParameters(std::string name, std::string basetag = "plant", bool intoFile = true, bool comments = true) const;             ///< write all organ type parameters into a xml file
     virtual std::string write(std::string name, bool intoFile = true) const;     /// Writes output based on file extension.
     virtual void writeVTP(int otype, std::ostream &os) const;                    ///< Writes VTP polyline output.
     virtual void writeGeometry(std::ostream &os) const;                          ///< Writes confining geometry as ParaView Python script.
     virtual std::string writeRSML(std::string name, bool intoFile = true) const; ///< writes a RSML file
     int getRSMLSkip() const { return rsmlSkip; }                                 ///< skips points in the RSML output (default = 0)
-    void setRSMLSkip(int skip) {
-        assert(skip >= 0 && "Organism::setRSMLSkip(): skip must be >= 0");
-        rsmlSkip = skip;
-    } ///< skips points in the RSML output (default = 0)
+    void setRSMLSkip(int skip) { assert(skip >= 0 && "Organism::setRSMLSkip(): skip must be >= 0"); rsmlSkip = skip; } ///< skips points in the RSML output (default = 0)
     std::vector<std::string> &getRSMLProperties() { return rsmlProperties; } ///< Returns mutable list of RSML property names.
 
     /* id management */
-    int getOrganIndex() {
-        organId++;
-        return organId;
-    } ///< returns next unique organ id, only organ constructors should call this
-    int getNodeIndex() {
-        nodeId++;
-        return nodeId;
-    } ///< returns next unique node id, only organ constructors should call this
+    int getOrganIndex() { organId++; return organId; } ///< returns next unique organ id, only organ constructors should call this
+    int getNodeIndex() { nodeId++; return nodeId; } ///< returns next unique node id, only organ constructors should call this
 
     /* discretisation*/
     void setMinDx(double dx) { minDx = dx; } ///< minimum segment size, smaller segments will be skipped
@@ -129,24 +124,10 @@ class Organism : public std::enable_shared_from_this<Organism> {
 
     /* random numbers */
     void setSeed(unsigned int seed); ///< Sets RNG seed.
-    void setRandomSeed(unsigned int seed) {
-        setSeed(seed);
-    } ///< renamed setSeed to avoid confusion with plant seed, but keep setSeed for backward compatibility
+    void setRandomSeed(unsigned int seed) { setSeed(seed); } ///< renamed setSeed to avoid confusion with plant seed, but keep setSeed for backward compatibility
     unsigned int getSeedVal() { return seed_val; }
-    double rand() {
-        if (stochastic) {
-            return UD(gen);
-        } else {
-            return 0.5;
-        }
-    } ///< uniformly distributed random number [0, 1)
-    double randn() {
-        if (stochastic) {
-            return ND(gen);
-        } else {
-            return 0.0;
-        }
-    } ///< normally distributed random number
+    double rand() { if (stochastic) { return UD(gen); } else { return 0.5; } } ///< uniformly distributed random number [0, 1)
+    double randn() { if (stochastic) { return ND(gen); } else { return 0.0; } } ///< normally distributed random number
     void setStochastic(bool stochastic_) { stochastic = stochastic_; } ///< Enables/disables stochastic sampling.
     bool getStochastic() { return stochastic; }                        ///< Returns stochastic sampling flag.
 
@@ -156,6 +137,11 @@ class Organism : public std::enable_shared_from_this<Organism> {
     int getDelayDefinition(int ot_lat);          ///< Returns delay-definition mode for a lateral organ type.
 
     int plantId; ///< Unique organism id (mainly for debugging/copy tracing).
+
+    virtual std::shared_ptr<Seed> createSeed();                                                                    ///< Factory method for creating a seed organ.
+    virtual std::shared_ptr<Root> createRoot(int subType, double delay, std::shared_ptr<Organ> parent, int pni);  ///< Factory method for creating roots, overridden by Plant to return Root instances.
+    virtual std::shared_ptr<Stem> createStem(int subType, double delay, std::shared_ptr<Organ> parent, int pni);  ///< Factory method for creating stems, overridden by Plant to return Stem instances.
+    virtual std::shared_ptr<Leaf> createLeaf(int subType, double delay, std::shared_ptr<Organ> parent, int pni);  ///< Factory method for creating leaves, overridden by Plant to return Leaf instances.
 
   protected:
     virtual tinyxml2::XMLElement *getRSMLMetadata(tinyxml2::XMLDocument &doc) const; ///< Builds RSML metadata node.

--- a/src/structural/Plant.cpp
+++ b/src/structural/Plant.cpp
@@ -108,7 +108,7 @@ void Plant::initialize(bool verbose, std::string mode) {
 
 void Plant::initializeLB(bool verbose) {
     reset(); // just in case
-    auto seed = std::make_shared<Seed>(shared_from_this());
+    auto seed = createSeed();
     this->addOrgan(seed);
     seed->initialize(verbose);
     initialize_(verbose);

--- a/src/structural/Root.cpp
+++ b/src/structural/Root.cpp
@@ -344,7 +344,7 @@ void StaticRoot::initializeLaterals() {
     // std::cout << lateralNodeIndices.size() << "\n";
     for (int i = 0; i < lateralNodeIndices.size(); i++) {
         int lni = lateralNodeIndices.at(i); // rename
-        std::shared_ptr<Organ> lateral = std::make_shared<Root>(plant.lock(), lateralTypes.at(i), lateralDelays.at(i), shared_from_this(), lni);
+        std::shared_ptr<Organ> lateral = plant.lock()->createRoot(lateralTypes.at(i), lateralDelays.at(i), shared_from_this(), lni);
         // lateral->addNode(getNode(lni), getNodeId(lni), lateralDelays.at(i));
         this->addChild(lateral);
     }

--- a/src/structural/RootSystem.cpp
+++ b/src/structural/RootSystem.cpp
@@ -135,7 +135,7 @@ void RootSystem::initializeLB(int basal, int shootborne, bool verbose)
 {
 	reset(); // just in case
     getNodeIndex(); // introduce an extra node at nodes[0]
-    seed = std::make_shared<Seed>(shared_from_this()); // introduce a 2nd node =>  2 nodes to make a seed segment
+    seed = createSeed(); // introduce a 2nd node =>  2 nodes to make a seed segment
 	initialize_(basal, shootborne, verbose);
 }
 

--- a/src/structural/Seed.cpp
+++ b/src/structural/Seed.cpp
@@ -270,14 +270,14 @@ std::string Seed::toString() const {
  * todo doc
  */
 std::shared_ptr<Organ> Seed::createRoot(std::shared_ptr<Organism> plant, int type, double delay) {
-    return std::make_shared<Root>(plant, type, delay, shared_from_this(), 0);
+    return plant->createRoot(type, delay, shared_from_this(), 0);
 }
 
 /**
  * todo doc// overwrite if you want to change the types
  */
 std::shared_ptr<Organ> Seed::createStem(std::shared_ptr<Organism> plant, int type, double delay) {
-    return std::make_shared<Stem>(plant, type, delay, shared_from_this(), 0);
+    return plant->createStem(type, delay, shared_from_this(), 0);
 }
 
 } // namespace CPlantBox


### PR DESCRIPTION
Instead of directly creating the plant organs, they are now created with createSeed, createRoot, ... in the Organsim class. If we want to play around with specialized organs, it makes it very easy to change standard behavior by just overriding these factory functions. 